### PR TITLE
Change the device number of the I2C bus on the GPIO pins

### DIFF
--- a/hummingboard.c
+++ b/hummingboard.c
@@ -397,7 +397,7 @@ static int hummingboardI2CSetup(int devId) {
 	int fd = 0;
 	const char *device = NULL;
 
-	device = "/dev/i2c-0";
+	device = "/dev/i2c-2";
 
 	if((fd = open(device, O_RDWR)) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->I2CSetup: Unable to open %s: %s", device, strerror(errno));


### PR DESCRIPTION
With the dtsi file from
https://github.com/SolidRun/linux-imx6-3.14/pull/19 the I2C device
controlled by the GPIO pins will be /dev/i2c-2

Tested on Arch Linux Arm and (I think) Debian
