### PR TITLE
Add SPI support to wiringX and implement for Hummingboard

### DIFF
--- a/hummingboard.c
+++ b/hummingboard.c
@@ -426,7 +426,7 @@ int hummingboardSPIGetFd(int channel) {
 
 int hummingboardSPIDataRW(int channel, unsigned char *data, int len) {
 	struct spi_ioc_transfer spi;
-	memset (&spi, 0, sizeof(spi));
+	memset(&spi, 0, sizeof(spi));
 	channel &= 1;
 
 	spi.tx_buf = (unsigned long)data;

--- a/hummingboard.c
+++ b/hummingboard.c
@@ -59,11 +59,11 @@ static int pinToGPIOAddr[NUM_PINS] = {
 };
 
 /* SPI Bus Parameters */
-static uint8_t     spiMode   = 0 ;
-static uint8_t     spiBPW    = 8 ;
+static uint8_t     spiMode   = 0;
+static uint8_t     spiBPW    = 8;
 static uint16_t    spiDelay  = 0;
-static uint32_t    spiSpeeds [2] ;
-static int         spiFds [2] ;
+static uint32_t    spiSpeeds[2];
+static int         spiFds[2];
 
 int hummingboardValidGPIO(int pin) {
 	if(pin >= 0 && pin <= 7) {
@@ -429,14 +429,14 @@ int hummingboardSPIDataRW(int channel, unsigned char *data, int len) {
 	memset (&spi, 0, sizeof(spi));
 	channel &= 1;
 
-	spi.tx_buf = (unsigned long) data;
-	spi.rx_buf = (unsigned long) data;
+	spi.tx_buf = (unsigned long)data;
+	spi.rx_buf = (unsigned long)data;
 	spi.len = len;
 	spi.delay_usecs = spiDelay;
 	spi.speed_hz = spiSpeeds[channel];
 	spi.bits_per_word = spiBPW;
 
-	if (ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
+	if(ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPIDataRW: Unable to read/write from channel %d: %s", channel, strerror(errno));
 		return -1;
 	}
@@ -449,13 +449,13 @@ int hummingboardSPISetup(int channel, int speed) {
 
 	channel &= 1;
 
-	if (channel == 0) {
+	if(channel == 0) {
 		device = "/dev/spidev1.0";
 	} else {
 		device = "/dev/spidev1.1";
 	}
 
-	if ((fd = open(device, O_RDWR)) < 0) {
+	if((fd = open(device, O_RDWR)) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to open %s: %s", device, strerror(errno));
 		return -1;
 	}
@@ -463,32 +463,32 @@ int hummingboardSPISetup(int channel, int speed) {
 	spiSpeeds[channel] = speed;
 	spiFds[channel] = fd;
 
-	if (ioctl(fd, SPI_IOC_WR_MODE, &spiMode) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_MODE, &spiMode) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s to write mode: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_MODE, &spiMode) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_MODE, &spiMode) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s to read mode: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s write bits_per_word: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &spiBPW) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &spiBPW) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s read bits_per_word: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s write max_speed: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPISetup: Unable to set %s read max_speed: %s", device, strerror(errno));
 		return -1;
 	}

--- a/raspberrypi.c
+++ b/raspberrypi.c
@@ -835,7 +835,7 @@ int raspberrypiSPIGetFd(int channel) {
 
 int raspberrypiSPIDataRW(int channel, unsigned char *data, int len) {
 	struct spi_ioc_transfer spi;
-	memset (&spi, 0, sizeof(spi)); // found at http://www.raspberrypi.org/forums/viewtopic.php?p=680665#p680665
+	memset(&spi, 0, sizeof(spi)); // found at http://www.raspberrypi.org/forums/viewtopic.php?p=680665#p680665
 	channel &= 1;
 
 	spi.tx_buf = (unsigned long)data;

--- a/raspberrypi.c
+++ b/raspberrypi.c
@@ -217,11 +217,11 @@ static int sysFds[64] = {
 };
 
 /* SPI Bus Parameters */
-static uint8_t     spiMode   = 0 ;
-static uint8_t     spiBPW    = 8 ;
+static uint8_t     spiMode   = 0;
+static uint8_t     spiBPW    = 8;
 static uint16_t    spiDelay  = 0;
-static uint32_t    spiSpeeds [2] ;
-static int         spiFds [2] ;
+static uint32_t    spiSpeeds[2];
+static int         spiFds[2];
 
 int raspberrypiValidGPIO(int pin) {
 	if(pinToGpio[pin] != -1) {
@@ -838,14 +838,14 @@ int raspberrypiSPIDataRW(int channel, unsigned char *data, int len) {
 	memset (&spi, 0, sizeof(spi)); // found at http://www.raspberrypi.org/forums/viewtopic.php?p=680665#p680665
 	channel &= 1;
 
-	spi.tx_buf = (unsigned long) data;
-	spi.rx_buf = (unsigned long) data;
+	spi.tx_buf = (unsigned long)data;
+	spi.rx_buf = (unsigned long)data;
 	spi.len = len;
 	spi.delay_usecs = spiDelay;
 	spi.speed_hz = spiSpeeds[channel];
 	spi.bits_per_word = spiBPW;
 
-	if (ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
+	if(ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPIDataRW: Unable to read/write from channel %d: %s", channel, strerror(errno));
 		return -1;
 	}
@@ -858,13 +858,13 @@ int raspberrypiSPISetup(int channel, int speed) {
 
 	channel &= 1;
 
-	if (channel == 0) {
+	if(channel == 0) {
 		device = "/dev/spidev0.0";
 	} else {
 		device = "/dev/spidev0.1";
 	}
 
-	if ((fd = open(device, O_RDWR)) < 0) {
+	if((fd = open(device, O_RDWR)) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to open device %s: %s", device, strerror(errno));
 		return -1;
 	}
@@ -872,32 +872,32 @@ int raspberrypiSPISetup(int channel, int speed) {
 	spiSpeeds[channel] = speed;
 	spiFds[channel] = fd;
 
-	if (ioctl(fd, SPI_IOC_WR_MODE, &spiMode) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_MODE, &spiMode) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set write mode for device %s: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_MODE, &spiMode) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_MODE, &spiMode) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set read mode for device %s: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set write bits_per_word for device %s: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &spiBPW) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &spiBPW) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set read bits_per_word for device %s: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0) {
+	if(ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set write max_speed for device %s: %s", device, strerror(errno));
 		return -1;
 	}
 
-	if (ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0) {
+	if(ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPISetup: Unable to set read max_speed for device %s: %s", device, strerror(errno));
 		return -1;
 	}

--- a/wiringX.c
+++ b/wiringX.c
@@ -94,6 +94,8 @@ void platform_register(struct platform_t **dev, const char *name) {
 	(*dev)->I2CWrite = NULL;
 	(*dev)->I2CWriteReg8 = NULL;
 	(*dev)->I2CWriteReg16 = NULL;
+	(*dev)->SPIGetFd = NULL;
+	(*dev)->SPIDataRW = NULL;
 
 	if(!((*dev)->name = malloc(strlen(name)+1))) {
 		wiringXLog(LOG_ERR, "out of memory");

--- a/wiringX.c
+++ b/wiringX.c
@@ -333,6 +333,60 @@ int wiringXI2CSetup(int devId) {
 	return -1;
 }
 
+int wiringXSPIGetFd(int channel) {
+	if(platform != NULL) {
+		if(platform->SPIGetFd) {
+			int x = platform->SPIGetFd(channel);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling SPIGetFd", platform->name);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support SPIGetFd", platform->name);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
+int wiringXSPIDataRW(int channel, unsigned char *data, int len) {
+	if(platform != NULL) {
+		if(platform->SPIDataRW) {
+			int x = platform->SPIDataRW(channel, data, len);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling SPIDataRW", platform->name);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support SPIDataRW", platform->name);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
+int wiringXSPISetup(int channel, int speed) {
+	if(platform != NULL) {
+		if(platform->SPISetup) {
+			int x = platform->SPISetup(channel, speed);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling SPISetup", platform->name);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support SPISetup", platform->name);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
 char *wiringXPlatform(void) {
 	return platform->name;
 }

--- a/wiringX.h
+++ b/wiringX.h
@@ -64,6 +64,9 @@ typedef struct platform_t {
 	int (*I2CWriteReg8)(int fd, int reg, int data);
 	int (*I2CWriteReg16)(int fd, int reg, int data);
 	int (*I2CSetup)(int devId);
+	int (*SPIGetFd)(int channel);
+	int (*SPIDataRW)(int channel, unsigned char *data, int len);
+	int (*SPISetup)(int channel, int speed);
 	int (*validGPIO)(int gpio);
 	int (*gc)(void);
 	struct platform_t *next;
@@ -87,6 +90,9 @@ int wiringXI2CWrite(int fd, int data);
 int wiringXI2CWriteReg8(int fd, int reg, int data);
 int wiringXI2CWriteReg16(int fd, int reg, int data);
 int wiringXI2CSetup(int devId);
+int wiringXSPIGetFd(int channel);
+int wiringXSPIDataRW(int channel, unsigned char *data, int len);
+int wiringXSPISetup(int channel, int speed);
 char *wiringXPlatform(void);
 int wiringXValidGPIO(int gpio);
 


### PR DESCRIPTION
With the dtsi file from
https://github.com/SolidRun/linux-imx6-3.14/pull/19 the SPI interface on the Hummingboard works.

Tested on Arch Linux Arm.

There is example code at https://gist.github.com/crazystick/4bd75a978fba91cfbea9
