### PR TITLE
Add python bindings for SPI and fix I2CSetup

### DIFF
--- a/python/examples/7seg.py
+++ b/python/examples/7seg.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Paul Adams <paul@thoughtcriminal.co.uk>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This example shows how to write to the Sparkfun 7-segment display
+# https://www.sparkfun.com/products/11442 with WiringX in Python.
+
+from time import sleep
+
+from wiringX import gpio
+
+# setup wiringX
+gpio.setup()
+
+# set up the SPI device
+fd = gpio.SPISetup(0, 250000)
+
+while True:
+    # write 1 2 3 4 to the display
+    data = gpio.SPIDataRW(0, bytes([0x01,0x02,0x03,0x04]), 4)
+
+    # set the decimal point to position 2
+    data = gpio.SPIDataRW(0, bytes([0x77,0x02]), 2)
+    sleep(1)
+
+    # clear the display
+    data = gpio.SPIDataRW(0, bytes([0x76]), 1)
+    sleep(1)

--- a/python/examples/tmp102.py
+++ b/python/examples/tmp102.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Copyright (c) 2015 Paul Adams <paul@thoughtcriminal.co.uk>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This example shows how to read temperature from the TMP102 I2C device
+# with WiringX in Python. It assumes that the sensor is configured at 
+# the default I2C address of 0x48
+
+from time import sleep
+
+from wiringX import gpio
+
+# setup wiringX
+gpio.setup()
+
+# get a handle to the sensor, using the default I2C address
+fd = gpio.I2CSetup(0x48)
+while True:
+    # read from the default register
+    data = gpio.I2CReadReg16(fd, 0x00)
+    reg = []
+    # calculate the temperature
+    reg.append((data>>8)&0xff)
+    reg.append(data&0xff)
+    res  = (reg[1] << 4) | (reg[0] >> 4)
+    res = res * 0.0625
+
+    # print the result
+    print(u'Temperature: ' + str(res) + u' C')
+    sleep(1)

--- a/python/wiringX/wiringx.c
+++ b/python/wiringX/wiringx.c
@@ -259,11 +259,43 @@ static PyObject *py_setupI2C(PyObject *self, PyObject *args) {
 		return NULL;
 	}
 
-	if(wiringXI2CSetup(device) == 0) {
-		return Py_True;
-	} else {
-		return Py_False;
+	return Py_BuildValue("i", wiringXI2CSetup(device));
+}
+
+static PyObject *py_SPIGetFd(PyObject *self, PyObject *args) {
+	int channel = 0;
+
+	if(!PyArg_ParseTuple(args, "i", &channel)) {
+		return NULL;
 	}
+
+	return Py_BuildValue("i", wiringXSPIGetFd(channel));
+}
+
+static PyObject *py_SPIDataRW(PyObject *self, PyObject *args) {
+	int channel = 0, len = 0;
+	unsigned char *data;
+	if(!PyArg_ParseTuple(args, "is#i", &channel, &data, &len)) {
+		return NULL;
+	}
+
+	int result = wiringXSPIDataRW(channel, data, len);
+
+	if(result < 0) {
+		return NULL;
+	}
+
+	return Py_BuildValue("s", data);
+}
+
+static PyObject *py_setupSPI(PyObject *self, PyObject *args) {
+	int channel = 0, speed = 0;
+
+	if(!PyArg_ParseTuple(args, "ii", &channel, &speed)) {
+		return NULL;
+	}
+
+	return Py_BuildValue("i", wiringXSPISetup(channel, speed));
 }
 
 static PyObject *py_setup(void) {
@@ -302,6 +334,9 @@ static PyMethodDef module_methods[] = {
     {"I2CWrite", py_I2CWrite, METH_VARARGS, "Write to I2C device"},
     {"I2CWriteReg8", py_I2CWriteReg8, METH_VARARGS, "Write to I2C device"},
     {"I2CWriteReg16", py_I2CWriteReg16, METH_VARARGS, "Write to I2C device"},
+    {"SPIGetFd", py_SPIGetFd, METH_VARARGS, "Get SPI file descriptor for channel"},
+    {"SPIDataRW", py_SPIDataRW, METH_VARARGS, "Read / write SPI device"},
+    {"SPISetup", py_setupSPI, METH_VARARGS, "Setup SPI device"},
     /*{"ISR", py_wiringXISR, METH_VARARGS,	"Set pin to interrupt"},
     {"waitForInterrupt", py_waitForInterrupt, METH_VARARGS,	"Wait for interrupt"},*/
 		


### PR DESCRIPTION
Added python bindings for the SPI functions SPIGetFd, SPIDataRW and
SPISetup

Fixed the I2CSetup function (which needs to return a file descriptor for
use by subsequent calls)

Added examples showing how to communicate with the TMP102 I2C
temperature sensor and the Sparkfun 7-segment display
