### PR TITLE
Fix issue with Python bindings caused by introduction of CI20 platform

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -5,12 +5,12 @@ from distutils.command.build_ext import build_ext as _build_ext
 import sys
 
 modules = [
-	Extension('wiringX.gpio', sources=['wiringX/wiringx.c', '../wiringX.c', '../hummingboard.c', '../bananapi.c', '../radxa.c', '../raspberrypi.c'], include_dirs=['../'], extra_compile_args=['-Wformat=0']),
+	Extension('wiringX.gpio', sources=['wiringX/wiringx.c', '../wiringX.c', '../hummingboard.c', '../bananapi.c', '../radxa.c', '../raspberrypi.c', '../ci20.c'], include_dirs=['../'], extra_compile_args=['-Wformat=0']),
 ]
 
 setup(
     name='wiringX',
-    version='0.5',
+    version='0.6',
     author='CurlyMo',
     author_email='curlymoo1@gmail.com',
     url='https://www.wiringx.org/',


### PR DESCRIPTION
this adds ci20.c to the compile path for Python bindings, otherwise you
get the following:

ImportError:
/usr/lib/python3.4/site-packages/wiringX/gpio.cpython-34m.so: undefined
symbol: ci20Init
