### PR TITLE
Added installation instructions on Arch Linux ARM

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Make sure you have cmake in both cases installed:
 sudo apt-get install cmake
 ```
 
+wiringX is available in the Arch Linux ARM repository. To install, simply:
+```
+pacman -S wiringx-git
+```
 Pin numbering of the Raspberry Pi, Hummingboard and BananaPi can be found here:
 https://projects.drogon.net/raspberry-pi/wiringpi/pins/
 

--- a/python/README.txt
+++ b/python/README.txt
@@ -2,6 +2,8 @@ This package export all wiringX function to python.
 
 Run "python setup.py install" to install.
 
+On Arch Linux ARM, install "python-wiringx-git" or "python2-wiringx-git" via Pacman
+
 To import:
    from wiringX import gpio
 


### PR DESCRIPTION
wiringX has been accepted into the ALARM repo, so it can just be installed!
