### PR TITLE
Adapt to updated spidev kernel 3.15+ API

### DIFF
--- a/ci20.c
+++ b/ci20.c
@@ -468,6 +468,12 @@ int ci20SPIDataRW(int channel, unsigned char *data, int len) {
 	spi.delay_usecs = spiDelay;
 	spi.speed_hz = spiSpeeds[channel];
 	spi.bits_per_word = spiBPW;
+#ifdef SPI_IOC_WR_MODE32
+	spi.tx_nbits = 0;
+#endif
+#ifdef SPI_IOC_RD_MODE32
+	spi.rx_nbits = 0;
+#endif
 
 	if(ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
 		wiringXLog(LOG_ERR, "ci20->SPIDataRW: Unable to read/write from channel %d: %s", channel, strerror(errno));

--- a/hummingboard.c
+++ b/hummingboard.c
@@ -435,6 +435,12 @@ int hummingboardSPIDataRW(int channel, unsigned char *data, int len) {
 	spi.delay_usecs = spiDelay;
 	spi.speed_hz = spiSpeeds[channel];
 	spi.bits_per_word = spiBPW;
+#ifdef SPI_IOC_WR_MODE32
+	spi.tx_nbits = 0;
+#endif
+#ifdef SPI_IOC_RD_MODE32
+	spi.rx_nbits = 0;
+#endif
 
 	if(ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
 		wiringXLog(LOG_ERR, "hummingboard->SPIDataRW: Unable to read/write from channel %d: %s", channel, strerror(errno));

--- a/raspberrypi.c
+++ b/raspberrypi.c
@@ -844,6 +844,12 @@ int raspberrypiSPIDataRW(int channel, unsigned char *data, int len) {
 	spi.delay_usecs = spiDelay;
 	spi.speed_hz = spiSpeeds[channel];
 	spi.bits_per_word = spiBPW;
+#ifdef SPI_IOC_WR_MODE32
+	spi.tx_nbits = 0;
+#endif
+#ifdef SPI_IOC_RD_MODE32
+	spi.rx_nbits = 0;
+#endif
 
 	if(ioctl(spiFds[channel], SPI_IOC_MESSAGE(1), &spi) < 0) {
 		wiringXLog(LOG_ERR, "raspberrypi->SPIDataRW: Unable to read/write from channel %d: %s", channel, strerror(errno));


### PR DESCRIPTION
New fields in spi_ioc_transfer struct: tx_nbits, rx_nbits
New IOCTLs: SPI_IOC_WR_MODE32, SPI_IOC_RD_MODE32 - we are checking for these to determine if the new fields are available in spi_ioc_transfer
see also https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=dc64d39b54c1e9db97a6fb1ca52598c981728157
