### PR TITLE
Add PWM for radxaboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ stripped so it only supports those features also supported by wiringX.
 Those features currently are:
 - GPIO reading, writing, and interrupts.
 - IC2 reading and writing.
+- Serial reading and writing.
+
+For radxa board, more features are added:
+- Analog input.
+- SPI reading and writing.
+- Hardware PWM output.
 
 The supported devices are:
 - Raspberry Pi
@@ -33,7 +39,7 @@ donate@pilight.org
 ```
 mkdir build
 cd build
-cmake ..
+cmake .. -DCMAKE_C_FLAGS=-fPIC
 make
 #For Debian based linuxes
 cpack -G DEB

--- a/examples/pwm.c
+++ b/examples/pwm.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "wiringX.h"
+
+int main(void) {
+	int pin = 4;
+
+	wiringXSetup();
+	pinMode(pin, PWM_OUTPUT);
+
+	wiringXPWMEnable(pin, 0);
+	wiringXSetPWM(pin, 1000, 50);
+	wiringXPWMEnable(pin, 1);
+
+	sleep(15);
+	wiringXPWMEnable(pin, 0);
+}

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -136,6 +136,8 @@ void platform_register(struct platform_t **dev, const char *name) {
 	(*dev)->SPIGetFd = NULL;
 	(*dev)->SPIDataRW = NULL;
 	(*dev)->analogRead = NULL;
+	(*dev)->pwmEnable = NULL;
+	(*dev)->setPWM = NULL;
 
 	if(((*dev)->name = malloc(strlen(name)+1)) == NULL) {
 		fprintf(stderr, "out of memory\n");
@@ -646,6 +648,43 @@ int wiringXSerialGetChar(int fd) {
 		wiringXLog(LOG_ERR, "Serial interface is not opened");
 		return -1;
 	}
+}
+
+//PWM
+int wiringXPWMEnable(int pin, int enable){
+	if(platform != NULL) {
+		if(platform->pwmEnable) {
+			int x = platform->pwmEnable(pin, enable);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling pwmEnable", platform->name);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support pwmEnable", platform->name);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
+int  wiringXSetPWM(int pin, float period_ms, float duty){
+	if(platform != NULL) {
+		if(platform->setPWM) {
+			int x = platform->setPWM(pin, period_ms, duty);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling setPWM", platform->name);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support setPWM", platform->name);
+			wiringXGC();
+		}
+	}
+	return -1;
 }
 
 char *wiringXPlatform(void) {

--- a/src/wiringX.h
+++ b/src/wiringX.h
@@ -80,6 +80,8 @@ typedef struct platform_t {
 	int (*SPIGetFd)(int channel);
 	int (*SPIDataRW)(int channel, unsigned char *data, int len);
 	int (*SPISetup)(int channel, int speed);
+	int (*pwmEnable)(int pin, int enable);
+	int (*setPWM)(int pin, float period_ms, float duty);
 	int (*validGPIO)(int gpio);
 	int (*gc)(void);
 	struct platform_t *next;
@@ -123,6 +125,8 @@ void wiringXSerialPuts(int fd, char *s);
 void wiringXSerialPrintf(int fd, char *message, ...);
 int wiringXSerialDataAvail(int fd);
 int wiringXSerialGetChar(int fd);
+int wiringXPWMEnable (int pin, int enable);
+int wiringXSetPWM(int pin, float period_ms, float duty);
 char *wiringXPlatform(void);
 int wiringXValidGPIO(int gpio);
 


### PR DESCRIPTION
For kernel version below 3.12, PWM is not supported so it is implemented by register control. For　kernel version higher than 3.12, kernel interface is used to implement PWM.
