### PR TITLE
Add INT_EDGE_NONE to disable interrupts again

### DIFF
--- a/src/bananapi.c
+++ b/src/bananapi.c
@@ -225,6 +225,8 @@ static int bananapiISR(int pin, int mode) {
 		sMode = "rising" ;
 	} else if(mode == INT_EDGE_BOTH) {
 		sMode = "both";
+	} else if(mode == INT_EDGE_NONE) {
+		sMode = "none";
 	} else {
 		wiringXLog(LOG_ERR, "bananapi->isr: Invalid mode. Should be INT_EDGE_BOTH, INT_EDGE_RISING, or INT_EDGE_FALLING");
 		return -1;

--- a/src/ci20.c
+++ b/src/ci20.c
@@ -261,6 +261,8 @@ static int ci20ISR(int pin, int mode) {
 		sMode = "rising" ;
 	} else if(mode == INT_EDGE_BOTH) {
 		sMode = "both";
+	} else if(mode == INT_EDGE_NONE) {
+		sMode = "none";
 	} else {
 		wiringXLog(LOG_ERR, "ci20->isr: Invalid mode. Should be INT_EDGE_BOTH, INT_EDGE_RISING, or INT_EDGE_FALLING");
 		return -1;

--- a/src/hummingboard.c
+++ b/src/hummingboard.c
@@ -233,6 +233,8 @@ static int hummingboardISR(int pin, int mode) {
 		sMode = "rising" ;
 	} else if(mode == INT_EDGE_BOTH) {
 		sMode = "both";
+	} else if(mode == INT_EDGE_NONE) {
+		sMode = "none";
 	} else {
 		wiringXLog(LOG_ERR, "hummingboard->isr: Invalid mode. Should be INT_EDGE_BOTH, INT_EDGE_RISING, or INT_EDGE_FALLING");
 		return -1;

--- a/src/radxa.c
+++ b/src/radxa.c
@@ -434,6 +434,8 @@ static int radxaISR(int pin, int mode) {
 		} else {
 			sMode = "both";
 		}
+	} else if(mode == INT_EDGE_NONE) {
+		sMode = "none";
 	} else {
 		wiringXLog(LOG_ERR, "radxa->isr: Invalid mode. Should be INT_EDGE_RISING, INT_EDGE_FALLING, or INT_EDGE_BOTH");
 		return -1;

--- a/src/raspberrypi.c
+++ b/src/raspberrypi.c
@@ -456,6 +456,8 @@ static int raspberrypiISR(int pin, int mode) {
 		sMode = "rising" ;
 	} else if(mode == INT_EDGE_BOTH) {
 		sMode = "both";
+	} else if(mode == INT_EDGE_NONE) {
+		sMode = "none";
 	} else {
 		wiringXLog(LOG_ERR, "raspberrypi->isr: Invalid mode. Should be INT_EDGE_BOTH, INT_EDGE_RISING, or INT_EDGE_FALLING");
 		return -1;

--- a/src/wiringX.h
+++ b/src/wiringX.h
@@ -54,6 +54,7 @@ extern "C" {
 #define INT_EDGE_FALLING	1
 #define INT_EDGE_RISING		2
 #define INT_EDGE_BOTH 		3
+#define INT_EDGE_NONE 		4
 
 #define	PWM_MODE_MS			0
 #define	PWM_MODE_BAL		1


### PR DESCRIPTION
Adding INT_EDGE_NONE to set edge sysfs-file back to "none".
Use case is an device causing real large amount of irqs and
I want to disable/enable irq handling to lower load on my
device.
