### PR TITLE
Multiple calls to wiringXISR without loosing files

### DIFF
--- a/src/bananapi.c
+++ b/src/bananapi.c
@@ -295,12 +295,14 @@ static int bananapiISR(int pin, int mode) {
 		return -1;
 	}
 
-	sprintf(path, "/sys/class/gpio/gpio%d/value", npin);
-	if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
-		wiringXLog(LOG_ERR, "bananapi->isr: Unable to open GPIO value interface: %s", strerror(errno));
-		return -1;
+	if (sysFds[pin] == -1) {
+		sprintf(path, "/sys/class/gpio/gpio%d/value", npin);
+		if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
+			wiringXLog(LOG_ERR, "bananapi->isr: Unable to open GPIO value interface: %s", strerror(errno));
+			return -1;
+		}
+		changeOwner(path);
 	}
-	changeOwner(path);
 
 	sprintf(path, "/sys/class/gpio/gpio%d/edge", npin);
 	changeOwner(path);
@@ -576,6 +578,7 @@ static int bananapiGC(void) {
 		}
 		if(sysFds[i] > 0) {
 			close(sysFds[i]);
+			sysFds[i] = -1;
 		}
 	}
 

--- a/src/ci20.c
+++ b/src/ci20.c
@@ -329,12 +329,14 @@ static int ci20ISR(int pin, int mode) {
 		return -1;	
 	}
 
-	sprintf(path, "/sys/class/gpio/gpio%d/value", pinToGpio[pin]);
-	if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
-		wiringXLog(LOG_ERR, "ci20->isr: Unable to open GPIO value interface: %s", strerror(errno));
-		return -1;
-	}
-	changeOwner(path);
+	if (sysFds[pin] == -1) {
+		sprintf(path, "/sys/class/gpio/gpio%d/value", pinToGpio[pin]);
+		if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
+			wiringXLog(LOG_ERR, "ci20->isr: Unable to open GPIO value interface: %s", strerror(errno));
+			return -1;
+		}
+		changeOwner(path);
+	} 
 
 	sprintf(path, "/sys/class/gpio/gpio%d/edge", pinToGpio[pin]);
 	changeOwner(path);
@@ -406,6 +408,7 @@ static int ci20GC(void) {
 		}
 		if(sysFds[i] > 0) {
 			close(sysFds[i]);
+			sysFds[i] = -1;
 		}
 	}
 

--- a/src/hummingboard.c
+++ b/src/hummingboard.c
@@ -310,12 +310,14 @@ static int hummingboardISR(int pin, int mode) {
 		return -1;
 	}
 
-	sprintf(path, "/sys/class/gpio/gpio%d/value", pinsToGPIO[pin]);
-	if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
-		wiringXLog(LOG_ERR, "hummingboard->isr: Unable to open GPIO value interface: %s", strerror(errno));
-		return -1;
+	if (sysFds[pin] == -1) {
+		sprintf(path, "/sys/class/gpio/gpio%d/value", pinsToGPIO[pin]);
+		if((sysFds[pin] = open(path, O_RDONLY)) < 0) {
+			wiringXLog(LOG_ERR, "hummingboard->isr: Unable to open GPIO value interface: %s", strerror(errno));
+			return -1;
+		}
+		changeOwner(path);
 	}
-	changeOwner(path);
 
 	sprintf(path, "/sys/class/gpio/gpio%d/edge", pinsToGPIO[pin]);
 	changeOwner(path);
@@ -377,6 +379,7 @@ static int hummingboardGC(void) {
 		}
 		if(sysFds[i] > 0) {
 			close(sysFds[i]);
+			sysFds[i] = -1;
 		}
 	}
 


### PR DESCRIPTION
If you call wiringXISR to configure a pin for interrupt mode
and want to change the configuration again the sysFds[i]
file descriptor is overwritten without being closed.
You can force the close by calling wiringXGC. But I think it would
be nicer if nothing gets lost. And you don't need to close the
file if you just want to reconfigure the pin.
