### PR TITLE
improve blink example

### DIFF
--- a/examples/blink.c
+++ b/examples/blink.c
@@ -4,14 +4,32 @@
 
 #include "wiringX.h"
 
-int main(void) {
+int main(int argc, char *argv[]) {
+	int pin = 0;
+
 	wiringXSetup();
 
-	pinMode(0, OUTPUT);
+	if (argc == 1) {
+		printf("blink: Using default GPIO 0\n");
+	} else {
+		if (argc == 2) {
+			pin = atoi(argv[1]);
+			if(wiringXValidGPIO(pin) != 0) {
+				printf("blink: Invalid GPIO %d\n", pin);
+				return -1;
+			}
+			printf("blink: Using GPIO %d\n", pin);
+		} else {
+			printf("blink: Too many arguments\n");
+			return -1;
+		}
+	}
+
+	pinMode(pin, OUTPUT);
 	while(1) {
-		digitalWrite(0, HIGH);
+		digitalWrite(pin, HIGH);
 		sleep(1);
-		digitalWrite(0, LOW);
+		digitalWrite(pin, LOW);
 		sleep(1);
 	}
 }


### PR DESCRIPTION
add the possibility to blink (wiringx-blink) to define a pin to use

the three usage examples are made with my other branch sunxidt 
##### without an argument

```
# wiringx-blink
sunxidt->identify: Detected Cubietech Cubietruck
running on a sunxidt
blink: Using default pin 0
```
##### with argument 30 => Pin30

```
# wiringx-blink 30
sunxidt->identify: Detected Cubietech Cubietruck
running on a sunxidt
blink: Using pin 30
```
##### with argument 34, Pin34 does not exist on this device

```
# wiringx-blink 34
sunxidt->identify: Detected Cubietech Cubietruck
running on a sunxidt
blink: Invalid pin number 34
```
