### PR TITLE
CMakeLists: add CMAKE_POSITION_INDEPENDENT_CODE to compile with -fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.9)
 
 project(wiringX C)
 
@@ -8,6 +8,7 @@ set(PROJECT_NAME wiringX)
 set(CMAKE_BUILD_TYPE Release)
 
 set(CMAKE_SKIP_RULE_DEPENDENCY TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 #Final compilation all platforms
 #Removing debugging for final compilation


### PR DESCRIPTION
hi,

by compiling wiringX from git i get this error on armv7h (RaspberryPi2 and Cubietruck)
I forgot to mentioned it on my last commit.

```
Scanning dependencies of target wiringx_shared
 [ 43%] Linking C shared library libwiringX.so
/usr/bin/ld: CMakeFiles/sources.dir/src/bananapi.c.o: relocation R_ARM_MOVW_ABS_NC against `a local symbol' can not be used when making a shared object; recompile with -fPIC
CMakeFiles/sources.dir/src/bananapi.c.o: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
CMakeFiles/wiringx_shared.dir/build.make:79: recipe for target 'libwiringX.so' failed
```

I found that global setting `set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)` in CMakeLists.txt fix this issue. This flag was the first time included in cmake version 2.8.9, so increase the required version.
