### PR TITLE
improve examples/read.c and examples/blink.c

### DIFF
--- a/examples/blink.c
+++ b/examples/blink.c
@@ -6,7 +6,7 @@
 
 char *usage = "Usage: %s GPIO\n"
 			"       GPIO is the GPIO to write\n"
-			"Example: %s 10";
+			"Example: %s 10\n";
 
 int main(int argc, char *argv[]) {
 	int gpio;

--- a/examples/blink.c
+++ b/examples/blink.c
@@ -4,14 +4,14 @@
 
 #include "wiringX.h"
 
-char *usage = "Usage: blink GPIO\n"
+char *usage = "Usage: %s GPIO\n"
 			"       GPIO is the GPIO to write\n"
-			"Example: blink 10";
+			"Example: %s 10";
 
 int main(int argc, char *argv[]) {
 	int gpio;
 	int i, n, value;
-	char ch;
+	char ch, str [100];
 
 	// first, check for a valid, numeric argument
 	// found at http://stackoverflow.com/questions/17292545
@@ -26,7 +26,8 @@ int main(int argc, char *argv[]) {
 	// expect 1 argument for the programm blink ('blink gpio')
 	// these are argv[0-1], so argc = 2
 	if(argc != 2) {
-		printf("%s\n", usage);
+		sprintf(str, usage, argv[0], argv[0]);
+		printf(str);
 		return -1;
 	}
 

--- a/examples/blink.c
+++ b/examples/blink.c
@@ -1,39 +1,46 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
 #include <unistd.h>
 
 #include "wiringX.h"
 
-char *usage = "Usage: %s GPIO\n"
-			"       GPIO is the GPIO to write\n"
-			"Example: %s 10\n";
+char *usage =
+	"Usage: %s GPIO\n"
+	"       GPIO is the GPIO to write to\n"
+	"Example: %s 10\n";
 
 int main(int argc, char *argv[]) {
-	int gpio;
-	int i, n, value;
-	char ch, str [100];
+	char *str = NULL;
+	char usagestr[120];
+	int gpio = 0, invalid = 0;
 
-	// first, check for a valid, numeric argument
-	// found at http://stackoverflow.com/questions/17292545
-	for(i=1; i<argc; i++) {
-		n = sscanf(argv[i], "%d%c", &value, &ch);
-		if (n != 1) {
-			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
-			return -1;
-		}
-	}
+	memset(usagestr, '\0', 120);
 
-	// expect 1 argument for the programm blink ('blink gpio')
-	// these are argv[0-1], so argc = 2
+	// expect only 1 argument => argc must be 2
 	if(argc != 2) {
-		sprintf(str, usage, argv[0], argv[0]);
-		printf(str);
+		snprintf(usagestr, 119, usage, argv[0], argv[0]);
+		printf(usagestr);
 		return -1;
 	}
 
-	wiringXSetup();
+	// check for a valid, numeric argument
+	str = argv[1];
+	while(*str != '\0') {
+		if(!isdigit(*str)) {
+			invalid = 1;
+		}
+		str++;
+	}
+	if(invalid == 1) {
+		printf("%s: Invalid GPIO %s\n", argv[0], argv[1]);
+		return -1;
+	}
 
 	gpio = atoi(argv[1]);
+
+	wiringXSetup();
 
 	if(wiringXValidGPIO(gpio) != 0) {
 		printf("%s: Invalid GPIO %d\n", argv[0], gpio);
@@ -42,8 +49,10 @@ int main(int argc, char *argv[]) {
 
 	pinMode(gpio, OUTPUT);
 	while(1) {
+		printf("Writing to GPIO %d: High\n", gpio);
 		digitalWrite(gpio, HIGH);
 		sleep(1);
+		printf("Writing to GPIO %d: Low\n", gpio);
 		digitalWrite(gpio, LOW);
 		sleep(1);
 	}

--- a/examples/blink.c
+++ b/examples/blink.c
@@ -4,32 +4,46 @@
 
 #include "wiringX.h"
 
+char *usage = "Usage: blink GPIO\n"
+			"       GPIO is the GPIO to write\n"
+			"Example: blink 10";
+
 int main(int argc, char *argv[]) {
-	int pin = 0;
+	int gpio;
+	int i, n, value;
+	char ch;
 
-	wiringXSetup();
-
-	if (argc == 1) {
-		printf("blink: Using default GPIO 0\n");
-	} else {
-		if (argc == 2) {
-			pin = atoi(argv[1]);
-			if(wiringXValidGPIO(pin) != 0) {
-				printf("blink: Invalid GPIO %d\n", pin);
-				return -1;
-			}
-			printf("blink: Using GPIO %d\n", pin);
-		} else {
-			printf("blink: Too many arguments\n");
+	// first, check for a valid, numeric argument
+	// found at http://stackoverflow.com/questions/17292545
+	for(i=1; i<argc; i++) {
+		n = sscanf(argv[i], "%d%c", &value, &ch);
+		if (n != 1) {
+			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
 			return -1;
 		}
 	}
 
-	pinMode(pin, OUTPUT);
+	// expect 1 argument for the programm blink ('blink gpio')
+	// these are argv[0-1], so argc = 2
+	if(argc != 2) {
+		printf("%s\n", usage);
+		return -1;
+	}
+
+	wiringXSetup();
+
+	gpio = atoi(argv[1]);
+
+	if(wiringXValidGPIO(gpio) != 0) {
+		printf("%s: Invalid GPIO %d\n", argv[0], gpio);
+		return -1;
+	}
+
+	pinMode(gpio, OUTPUT);
 	while(1) {
-		digitalWrite(pin, HIGH);
+		digitalWrite(gpio, HIGH);
 		sleep(1);
-		digitalWrite(pin, LOW);
+		digitalWrite(gpio, LOW);
 		sleep(1);
 	}
 }

--- a/examples/read.c
+++ b/examples/read.c
@@ -4,15 +4,15 @@
 
 #include "wiringX.h"
 
-char *usage = "Usage: read GPIO GPIO\n"
+char *usage = "Usage: %s GPIO GPIO\n"
 			"       first GPIO to write to = output\n"
 			"       second GPIO to read from = input\n"
-			"Example: read 4 23";
+			"Example: %s 4 23";
 
 int main(int argc, char *argv[]) {
 	int gpio_out, gpio_in;
 	int i, n, value;
-	char ch;
+	char ch, str [100];
 
 	// first, check for valid, numeric arguments
 	// found at http://stackoverflow.com/questions/17292545
@@ -27,7 +27,8 @@ int main(int argc, char *argv[]) {
 	// expect 2 arguments for the programm read ('read gpio_out gpio_in')
 	// these are argv[0-2], so argc = 3
 	if(argc != 3) {
-		printf("%s\n", usage);
+		sprintf(str, usage, argv[0], argv[0]);
+		printf(str);
 		return -1;
 	}
 

--- a/examples/read.c
+++ b/examples/read.c
@@ -4,19 +4,61 @@
 
 #include "wiringX.h"
 
-int main(void) {
+char *usage = "Usage: read GPIO GPIO\n"
+			"       first GPIO to write to = output\n"
+			"       second GPIO to read from = input\n"
+			"Example: read 4 23";
+
+int main(int argc, char *argv[]) {
+	int gpio_out, gpio_in;
+	int i, n, value;
+	char ch;
+
+	// first, check for valid, numeric arguments
+	// found at http://stackoverflow.com/questions/17292545
+	for(i=1; i<argc; i++) {
+		n = sscanf(argv[i], "%d%c", &value, &ch);
+		if (n != 1) {
+			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
+			return -1;
+		}
+	}
+
+	// expect 2 arguments for the programm read ('read gpio_out gpio_in')
+	// these are argv[0-2], so argc = 3
+	if(argc != 3) {
+		printf("%s\n", usage);
+		return -1;
+	}
+
 	wiringXSetup();
 
-	pinMode(0, OUTPUT);
-	pinMode(1, INPUT);
+	gpio_out = atoi(argv[1]);
+	gpio_in = atoi(argv[2]);
+	if(gpio_out == gpio_in) {
+		printf("%s: GPIO for output and input should not be the same\n", argv[0]);
+		return -1;
+	}
+	if(wiringXValidGPIO(gpio_out) != 0) {
+		printf("%s: Invalid GPIO %d for output\n", argv[0], gpio_out);
+		return -1;
+	}
+	if(wiringXValidGPIO(gpio_in) != 0) {
+		printf("%s: Invalid GPIO %d for input\n", argv[0], gpio_in);
+		return -1;
+	}
+
+	pinMode(gpio_out, OUTPUT);
+	pinMode(gpio_in, INPUT);
+
 	while(1) {
-		printf("Writing to pin 0: High\n");
-		digitalWrite(0, HIGH);
-		printf("Reading from pin 1: %d\n", digitalRead(1));
+		printf("Writing to GPIO %d: High\n", gpio_out);
+		digitalWrite(gpio_out, HIGH);
+		printf("Reading from GPIO %d: %d\n", gpio_in, digitalRead(gpio_in));
 		sleep(1);
-		printf("Writing to pin 0: Low\n");
-		digitalWrite(0, LOW);
-		printf("Reading from pin 1: %d\n", digitalRead(1));
+		printf("Writing to GPIO %d: Low\n", gpio_out);
+		digitalWrite(gpio_out, LOW);
+		printf("Reading from GPIO %d: %d\n", gpio_in, digitalRead(gpio_in));
 		sleep(1);
 	}
 }

--- a/examples/read.c
+++ b/examples/read.c
@@ -7,7 +7,7 @@
 char *usage = "Usage: %s GPIO GPIO\n"
 			"       first GPIO to write to = output\n"
 			"       second GPIO to read from = input\n"
-			"Example: %s 4 23";
+			"Example: %s 4 23\n";
 
 int main(int argc, char *argv[]) {
 	int gpio_out, gpio_in;

--- a/examples/read.c
+++ b/examples/read.c
@@ -1,38 +1,45 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
 #include <unistd.h>
 
 #include "wiringX.h"
 
-char *usage = "Usage: %s GPIO GPIO\n"
-			"       first GPIO to write to = output\n"
-			"       second GPIO to read from = input\n"
-			"Example: %s 4 23\n";
+char *usage =
+	"Usage: %s GPIO GPIO\n"
+	"       first GPIO to write to = output\n"
+	"       second GPIO to read from = input\n"
+	"Example: %s 4 23\n";
 
 int main(int argc, char *argv[]) {
-	int gpio_out, gpio_in;
-	int i, n, value;
-	char ch, str [100];
+	char *str = NULL;
+	char usagestr[160];
+	int i = 0, gpio_out = 0, gpio_in = 0, invalid = 0;
 
-	// first, check for valid, numeric arguments
-	// found at http://stackoverflow.com/questions/17292545
-	for(i=1; i<argc; i++) {
-		n = sscanf(argv[i], "%d%c", &value, &ch);
-		if (n != 1) {
-			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
-			return -1;
-		}
-	}
+	memset(usagestr, '\0', 160);
 
-	// expect 2 arguments for the programm read ('read gpio_out gpio_in')
-	// these are argv[0-2], so argc = 3
+	// expect 2 arguments => argc must be 3
 	if(argc != 3) {
-		sprintf(str, usage, argv[0], argv[0]);
-		printf(str);
+		snprintf(usagestr, 159, usage, argv[0], argv[0]);
+		printf(usagestr);
 		return -1;
 	}
 
-	wiringXSetup();
+	// check for valid, numeric arguments
+	for(i=1; i<argc; i++) {
+		str = argv[i];
+		while(*str != '\0') {
+			if(!isdigit(*str)) {
+				invalid = 1;
+			}
+			str++;
+		}
+		if(invalid == 1) {
+			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
+	        return -1;
+		}
+	}
 
 	gpio_out = atoi(argv[1]);
 	gpio_in = atoi(argv[2]);
@@ -40,6 +47,9 @@ int main(int argc, char *argv[]) {
 		printf("%s: GPIO for output and input should not be the same\n", argv[0]);
 		return -1;
 	}
+
+	wiringXSetup();
+
 	if(wiringXValidGPIO(gpio_out) != 0) {
 		printf("%s: Invalid GPIO %d for output\n", argv[0], gpio_out);
 		return -1;


### PR DESCRIPTION
hi,

i have made some changes to read.c. 
Both GPIO's must be set manual by the user, there are no default GPIO's and both must be numeric. Here are some examples:

```
# wiringx-read
Usage: read GPIO GPIO
   first GPIO to write = output
   second GPIO to read from = input
Example: read 4 23

# wiringx-read 24
Usage: read GPIO GPIO
   first GPIO to write = output
   second GPIO to read from = input
Example: read 4 23

# wiringx-read 24h 25
read: Invalid GPIO 24h

# wiringx-read 24 25j
read: Invalid GPIO 25j

# wiringx-read 24 25 7
Usage: read GPIO GPIO
    first GPIO to write = output
   second GPIO to read from = input
Example: read 4 23

# wiringx-read 24 25
running on a raspberrypi
Writing to GPIO 24: High
Reading from GPIO 25: 1
Writing to GPIO 24: Low
Reading from GPIO 25: 0
Writing to GPIO 24: High
Reading from GPIO 25: 1
Writing to GPIO 24: Low
Reading from GPIO 25: 0
Writing to GPIO 24: High
Reading from GPIO 25: 1
Writing to GPIO 24: Low
Reading from GPIO 25: 0
Writing to GPIO 24: High
Reading from GPIO 25: 0
```

So make the same changes to blink.c, there is no more a default GPIO, if the user does not set one.

```
# wiringx-blink 
Usage: blink GPIO
   GPIO is the GPIO to write
Example: blink 10

# wiringx-blink Three
blink: Invalid GPIO Three

# wiringx-blink 24h
blink: Invalid GPIO 24h

# wiringx-blink 24 25
Usage: blink GPIO
   GPIO is the GPIO to write
Example: blink 10

# wiringx-blink 24
running on a raspberrypi
```

As i reading through my own words, i see that the name of the program in the output should be replaced by argv[0], so name will be the same as you calling the program.

Please take a look and say what you are thinking.
