### PR TITLE
README.md: fix link to site with the pin numbering (wiringx.org)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,5 @@ wiringX is available in the Arch Linux ARM repository. To install, simply:
 ```
 pacman -S wiringx-git
 ```
-Pin numbering of the Raspberry Pi, Hummingboard and BananaPi can be found here:
-https://projects.drogon.net/raspberry-pi/wiringpi/pins/
-
-Pin numbering for the Radxa Rock can be found here:
-http://radxa.com/Rock/extension_header
+Pin numbering of the Raspberry Pi, Hummingboard, BananaPi and Radxa Rock can be found here:
+http://wiringx.org/


### PR DESCRIPTION
should be set to this
