### PR TITLE
examples/interrupt.c: enhance

### DIFF
--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -66,7 +66,6 @@ int main(int argc, char *argv[]) {
 		return -1;
 	}
 
-
 	wiringXSetup();
 
 	if(wiringXValidGPIO(gpio_out) != 0) {
@@ -74,7 +73,7 @@ int main(int argc, char *argv[]) {
 		return -1;
 	}
 	if(wiringXValidGPIO(gpio_in) != 0) {
-		printf("%s: Invalid GPIO %d for input (interrupt) \n", argv[0], gpio_in);
+		printf("%s: Invalid GPIO %d for input (interrupt)\n", argv[0], gpio_in);
 		return -1;
 	}
 

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -1,34 +1,107 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <sys/syscall.h>
 
 #include "wiringX.h"
 
-void *interrupt(void *param) {
-	while(1) {
-		if(waitForInterrupt(1, 1000) > 0) {
-			printf("interrupt\n");
+char *usage =
+	"Usage: %s GPIO GPIO\n"
+	"       first GPIO to write to = output\n"
+	"       second GPIO reacts on an interrupt = input\n"
+	"Example: %s 16 20\n";
+
+void *interrupt(void *gpio_void_ptr) {
+	int i = 0;
+	int gpio = *(int *)gpio_void_ptr;
+
+	while(++i < 20) {
+		if(waitForInterrupt(gpio, 1000) > 0) {
+			printf(">>Interrupt on GPIO %d\n", gpio);
 		} else {
-			printf("timeout\n");
+			printf("  Timeout on GPIO %d\n", gpio);
 		}
 	}
+	return 0;
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
 	pthread_t pth;
+	char *str = NULL;
+	char usagestr[180];
+	int gpio_out = 0, gpio_in = 0;
+	int i = 0, err = 0, invalid = 0;
+
+	memset(usagestr, '\0', 180);
+
+	// expect 2 arguments => argc must be 3
+	if(argc != 3) {
+		snprintf(usagestr, 179, usage, argv[0], argv[0]);
+		printf(usagestr);
+		return -1;
+	}
+
+	// check for valid, numeric arguments
+	for(i=1; i<argc; i++) {
+		str = argv[i];
+		while(*str != '\0') {
+			if(!isdigit(*str)) {
+				invalid = 1;
+			}
+			str++;
+		}
+		if(invalid == 1) {
+			printf("%s: Invalid GPIO %s\n", argv[0], argv[i]);
+	        return -1;
+		}
+	}
+
+	gpio_out = atoi(argv[1]);
+	gpio_in = atoi(argv[2]);
+	if(gpio_out == gpio_in) {
+		printf("%s: GPIO for output and input (interrupt) should not be the same\n", argv[0]);
+		return -1;
+	}
+
 
 	wiringXSetup();
 
-	pinMode(0, OUTPUT);
-	wiringXISR(1, INT_EDGE_BOTH);
+	if(wiringXValidGPIO(gpio_out) != 0) {
+		printf("%s: Invalid GPIO %d for output\n", argv[0], gpio_out);
+		return -1;
+	}
+	if(wiringXValidGPIO(gpio_in) != 0) {
+		printf("%s: Invalid GPIO %d for input (interrupt) \n", argv[0], gpio_in);
+		return -1;
+	}
 
-	pthread_create(&pth, NULL, interrupt, NULL);
+	pinMode(gpio_out, OUTPUT);
+	if((wiringXISR(gpio_in, INT_EDGE_BOTH)) != 0) {
+		return -1;
+	}
 
-	while(1) {
-		digitalWrite(0, HIGH);
+	err = pthread_create(&pth, NULL, interrupt, &gpio_in);
+	if(err != 0) {
+		printf("Can't create thread: [%s]\n", strerror(err));
+		return -1;
+	} else {
+		printf("Thread created succesfully\n");
+	}
+
+	for(i=0; i<5; i++) {
+		printf("  Writing to GPIO %d: High\n", gpio_out);
+		digitalWrite(gpio_out, HIGH);
 		sleep(1);
-		digitalWrite(0, LOW);
+		printf("  Writing to GPIO %d: Low\n", gpio_out);
+		digitalWrite(gpio_out, LOW);
 		sleep(2);
 	}
+
+	printf("Main finshed, waiting for thread ...\n");
+	pthread_join(pth, NULL);
+
+	return 0;
 }

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 		sleep(2);
 	}
 
-	printf("Main finshed, waiting for thread ...\n");
+	printf("Main finished, waiting for thread ...\n");
 	pthread_join(pth, NULL);
 
 	return 0;


### PR DESCRIPTION
hi,

i have also made changes to examples/interrupt.c. 

Now the main will run only for 15 sec and the thread for 20 sec. 
Wait after the loop in main till the thread has finished and exit the main.

Here ist the output from my Raspberry Pi2

```
# ./interrupt 22 23
running on a raspberrypi
Thread created succesfully
  Writing to GPIO 22: High
>>Interrupt on GPIO 23
  Writing to GPIO 22: Low
>>Interrupt on GPIO 23
  Timeout on GPIO 23
  Writing to GPIO 22: High
>>Interrupt on GPIO 23
  Writing to GPIO 22: Low
>>Interrupt on GPIO 23
  Timeout on GPIO 23
  Writing to GPIO 22: High
>>Interrupt on GPIO 23
  Writing to GPIO 22: Low
>>Interrupt on GPIO 23
  Timeout on GPIO 23
  Writing to GPIO 22: High
>>Interrupt on GPIO 23
  Writing to GPIO 22: Low
>>Interrupt on GPIO 23
  Timeout on GPIO 23
  Writing to GPIO 22: High
>>Interrupt on GPIO 23
  Writing to GPIO 22: Low
>>Interrupt on GPIO 23
  Timeout on GPIO 23
Main finshed, waiting for thread ...
  Timeout on GPIO 23
  Timeout on GPIO 23
  Timeout on GPIO 23
  Timeout on GPIO 23
```

Usage and Example looks like this:

```
Usage: ./interrupt GPIO GPIO
       first GPIO to write to = output
       second GPIO reacts on an interrupt = input
Example: ./interrupt 16 20
```

Please have a look

regards
MichaeL
