### PR TITLE
Update of wiringX numbering for high numbers (header pins 27-40)

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,25 +191,25 @@
 								<td class="thead">wiringX #</td>
 							</tr>
 							<tr>
-								<td>-</td><td>-</td><td>-</td><td class="header">27</td><td class="header">28</td><td>-</td><td>-</td><td>-</td>
+								<td>30</td><td>?</td><td class="gpio">ID_SD</td><td class="header">27</td><td class="header">28</td><td class="gpio">ID_SC</td><td>?</td><td>31</td>
 							</tr>
 							<tr>
 								<td>21</td><td>5</td><td class="gpio">GPIO 21</td><td class="header">29</td><td class="header">30</td><td class="gnd">0v</td><td>-</td><td>-</td>
 							</tr>
 							<tr>
-								<td>22</td><td>6</td><td class="gpio">GPIO 22</td><td class="header">31</td><td class="header">32</td><td class="gpio">GPIO 23</td><td>13</td><td>23</td>
+								<td>22</td><td>6</td><td class="gpio">GPIO 22</td><td class="header">31</td><td class="header">32</td><td class="gpio">GPIO 23</td><td>13</td><td>26</td>
 							</tr>
 							<tr>
-								<td>24</td><td>19</td><td class="gpio">GPIO 24</td><td class="header">33</td><td class="header">34</td><td class="gnd">0v</td><td>-</td><td>-</td>
+								<td>23</td><td>19</td><td class="gpio">GPIO 24</td><td class="header">33</td><td class="header">34</td><td class="gnd">0v</td><td>-</td><td>-</td>
 							</tr>
 							<tr>
-								<td>-</td><td>-</td><td class="gnd">0v</td><td class="header">35</td><td class="header">36</td><td class="gpio">GPIO 25</td><td>26</td><td>25</td>
+								<td>24</td><td>-</td><td class="gpio">?</td><td class="header">35</td><td class="header">36</td><td class="gpio">GPIO 25</td><td>26</td><td>27</td>
 							</tr>
 							<tr>
-								<td>26</td><td>12</td><td class="gpio">GPIO 26</td><td class="header">37</td><td class="header">38</td><td class="gpio">GPIO 27</td><td>16</td><td>27</td>
+								<td>25</td><td>12</td><td class="gpio">GPIO 26</td><td class="header">37</td><td class="header">38</td><td class="gpio">GPIO 27</td><td>16</td><td>28</td>
 							</tr>
 							<tr>
-								<td>28</td><td>20</td><td class="gpio">GPIO 28</td><td class="header">39</td><td class="header">40</td><td class="gpio">GPIO 29</td><td>21</td><td>29</td>
+								<td>-</td><td>-</td><td class="gnd">0v</td><td class="header">39</td><td class="header">40</td><td class="gpio">GPIO 29</td><td>21</td><td>29</td>
 							</tr>
 							<tr>
 								<td class="thead">wiringX #</td>


### PR DESCRIPTION
Based on measurements on my RPi 1 B+ and information from wiringPi, since numbering is equal to wiringPi.
Based on http://forum.pilight.org/Thread-wiringX-pin-numbering
Note: information is still incomplete, I added question marks (?) for this.
