### PR TITLE
replace printf by puts where no format is used

### DIFF
--- a/examples/blink.c
+++ b/examples/blink.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
 	// expect only 1 argument => argc must be 2
 	if(argc != 2) {
 		snprintf(usagestr, 119, usage, argv[0], argv[0]);
-		printf(usagestr);
+		puts(usagestr);
 		return -1;
 	}
 

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
 	// expect 2 arguments => argc must be 3
 	if(argc != 3) {
 		snprintf(usagestr, 179, usage, argv[0], argv[0]);
-		printf(usagestr);
+		puts(usagestr);
 		return -1;
 	}
 

--- a/examples/read.c
+++ b/examples/read.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 	// expect 2 arguments => argc must be 3
 	if(argc != 3) {
 		snprintf(usagestr, 159, usage, argv[0], argv[0]);
-		printf(usagestr);
+		puts(usagestr);
 		return -1;
 	}
 

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -69,7 +69,7 @@ void _fprintf(int prio, const char *format_str, ...) {
 	va_start(ap, format_str);
 	vsprintf(line, format_str, ap);
 	strcat(line, "\n");
-	fprintf(stderr, line);
+	fputs(line, stderr);
 	va_end(ap);
 }
 


### PR DESCRIPTION
Fixes error messages like: src/wiringX.c:72:2: error: format not a string literal and no format arguments [-Werror=format-security] triggered by fprintf(stderr, line);

This is required to build with the Debian distro CFLAGS
