### PR TITLE
radxa rock board added emulate both edge triggered interrupts

### DIFF
--- a/src/radxa.c
+++ b/src/radxa.c
@@ -389,7 +389,7 @@ static char radxaKernelVer(void) {
 static int radxaISR(int pin, int mode) {
 	int i = 0, fd = 0, count = 0;
 	int match = 0;
-	char kernelVer = 0, pinbaseFlag = 0, edgeFlag = 0;
+	char kernelVer = 0, pinbaseFlag = 0;
 	const char *sMode = NULL;
 	char path[35], c, line[120];
 	FILE *f = NULL;
@@ -421,19 +421,13 @@ static int radxaISR(int pin, int mode) {
 
 	kernelVer = radxaKernelVer();
 	pinbaseFlag = kernelVer & 0x02;
-	edgeFlag = kernelVer & 0x01;
 
 	if(mode == INT_EDGE_FALLING) {
 		sMode = "falling" ;
 	} else if(mode == INT_EDGE_RISING) {
 		sMode = "rising" ;
 	} else if(mode == INT_EDGE_BOTH) {
-		if(edgeFlag != 0) {
-			wiringXLog(LOG_ERR, "radxa->isr: Kernel version below 3.12 doesn's support both edge interruption.", sMode);
-			return -1;
-		} else {
-			sMode = "both";
-		}
+		sMode = "both";
 	} else if(mode == INT_EDGE_NONE) {
 		sMode = "none";
 	} else {


### PR DESCRIPTION
Hello, we have added  and tested both edge triggered interrupts function for radxa rock board.
https://github.com/radxa/linux-rockchip/commit/6650a736ff6a9d8043e8754d416f70d3d83ca051
