### PR TITLE
src/i2dev: "extern inline" in a .c file

### DIFF
--- a/src/i2c-dev.c
+++ b/src/i2c-dev.c
@@ -15,7 +15,7 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
-inline __s32 i2c_smbus_access(int fd, char rw, int cmd, int size, union i2c_smbus_data *data) {
+extern inline __s32 i2c_smbus_access(int fd, char rw, int cmd, int size, union i2c_smbus_data *data) {
 	struct i2c_smbus_ioctl_data args;
 
 	args.read_write = rw;
@@ -26,7 +26,7 @@ inline __s32 i2c_smbus_access(int fd, char rw, int cmd, int size, union i2c_smbu
 	return ioctl(fd, I2C_SMBUS, &args);
 }
 
-inline __s32 i2c_smbus_read_byte(int fd) {
+extern inline __s32 i2c_smbus_read_byte(int fd) {
 	union i2c_smbus_data data;
 	if(i2c_smbus_access(fd, I2C_SMBUS_READ, 0, I2C_SMBUS_BYTE, &data) <= 0) {
 		return -1;
@@ -35,11 +35,11 @@ inline __s32 i2c_smbus_read_byte(int fd) {
 	}
 }
 
-inline __s32 i2c_smbus_write_byte(int fd, int value) {
+extern inline __s32 i2c_smbus_write_byte(int fd, int value) {
 	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, value, I2C_SMBUS_BYTE, NULL);
 }
 
-inline __s32 i2c_smbus_read_byte_data(int fd, int cmd) {
+extern inline __s32 i2c_smbus_read_byte_data(int fd, int cmd) {
 	union i2c_smbus_data data;
 	if(i2c_smbus_access(fd, I2C_SMBUS_READ, cmd, I2C_SMBUS_BYTE_DATA, &data) <= 0) {
 		return -1;
@@ -48,13 +48,13 @@ inline __s32 i2c_smbus_read_byte_data(int fd, int cmd) {
 	}
 }
 
-inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value) {
+extern inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value) {
 	union i2c_smbus_data data;
 	data.byte = value;
 	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_BYTE_DATA, &data);
 }
 
-inline __s32 i2c_smbus_read_word_data(int fd, int cmd) {
+extern inline __s32 i2c_smbus_read_word_data(int fd, int cmd) {
 	union i2c_smbus_data data;
 	if(i2c_smbus_access(fd, I2C_SMBUS_READ, cmd, I2C_SMBUS_WORD_DATA, &data) <= 0) {
 		return -1;
@@ -63,7 +63,7 @@ inline __s32 i2c_smbus_read_word_data(int fd, int cmd) {
 	}
 }
 
-inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value) {
+extern inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value) {
 	union i2c_smbus_data data;
 	data.word = value;
 

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -14,12 +14,12 @@
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
-extern inline __s32 i2c_smbus_access(int fd, char rw, int cmd, int size, union i2c_smbus_data *data);
-extern inline __s32 i2c_smbus_read_byte(int fd);
-extern inline __s32 i2c_smbus_write_byte(int fd, int value);
-extern inline __s32 i2c_smbus_read_byte_data(int fd, int cmd);
-extern inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value);
-extern inline __s32 i2c_smbus_read_word_data(int fd, int cmd);
-extern inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value);
+inline __s32 i2c_smbus_access(int fd, char rw, int cmd, int size, union i2c_smbus_data *data);
+inline __s32 i2c_smbus_read_byte(int fd);
+inline __s32 i2c_smbus_write_byte(int fd, int value);
+inline __s32 i2c_smbus_read_byte_data(int fd, int cmd);
+inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value);
+inline __s32 i2c_smbus_read_word_data(int fd, int cmd);
+inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value);
 
 #endif


### PR DESCRIPTION
builds fine with these changes, but get still the warnings :

```
i2c-dev.h:23:14: warning: inline function 'i2c_smbus_write_word_data' declared but never defined
 inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value);

i2c-dev.h:22:14: warning: inline function 'i2c_smbus_read_word_data' declared but never defined
 inline __s32 i2c_smbus_read_word_data(int fd, int cmd);
. . .
```
