### PR TITLE
cpack: correct package generator name "DEB RPM" -> "DEB" "RPM"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ configure_file("${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake.in"
     IMMEDIATE @ONLY)
 add_custom_target(uninstall COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
-set(CPACK_GENERATOR "DEB RPM")
+set(CPACK_GENERATOR "DEB" "RPM")
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local")
 set(CPACK_SOURCE_STRIP_FILES TRUE)
 set(CPACK_STRIP_FILES TRUE)


### PR DESCRIPTION
Instead of space-separated, the generators to use with cpack must
be passed as a cmake list.

BEFORE:
 make package
[ 90%] Built target sources
[ 90%] Built target wiringx_shared
[ 93%] Built target wiringx-blink
[ 96%] Built target wiringx-interrupt
[100%] Built target wiringx-read
[100%] Built target wiringx_static
Run CPack packaging tool...
CPack Error: Cannot initialize CPack generator: DEB RPM
Makefile:107: recipe for target 'package' failed
make: **\* [package] Error 1

NOW:
make package
[ 90%] Built target sources
[ 90%] Built target wiringx_shared
[ 93%] Built target wiringx-blink
[ 96%] Built target wiringx-interrupt
[100%] Built target wiringx-read
[100%] Built target wiringx_static
Run CPack packaging tool...
CPack: Create package using DEB
CPack: Install projects
CPack: - Run preinstall target for: wiringX
CPack: - Install project: wiringX
CPack: Create package
CPack: - package: /home/debian/SOURCES/wiringX/build/libwiringx-185-g08bb139.deb generated.
CPack: Create package using RPM
CPack: Install projects
CPack: - Run preinstall target for: wiringX
CPack: - Install project: wiringX
CPack: Create package
CPackRPM: Will use GENERATED spec file: /home/debian/SOURCES/wiringX/build/_CPack_Packages/Linux/RPM/SPECS/libwiringx.spec
CPack: - package: /home/debian/SOURCES/wiringX/build/libwiringx-185-g08bb139.rpm generated.
