### PR TITLE
Added hardware PWM for Raspi 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 python/__pycache__/
 python/build/
 build
+.cproject
+.project
+.settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,10 @@ project(wiringX C)
 set(PROJECT_VERSION 1.0)
 set(PROJECT_NAME wiringX)
 
-set(CMAKE_BUILD_TYPE Release)
+if( NOT CMAKE_BUILD_TYPE )
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
 
 set(CMAKE_SKIP_RULE_DEPENDENCY TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
@@ -115,10 +118,12 @@ set_target_properties(wiringx_shared wiringx_static PROPERTIES OUTPUT_NAME wirin
 add_executable(wiringx-blink ${PROJECT_SOURCE_DIR}/examples/blink.c)
 add_executable(wiringx-interrupt ${PROJECT_SOURCE_DIR}/examples/interrupt.c)
 add_executable(wiringx-read ${PROJECT_SOURCE_DIR}/examples/read.c)
+add_executable(wiringx-pwm ${PROJECT_SOURCE_DIR}/examples/pwm.c)
 
 target_link_libraries(wiringx-blink wiringx_shared)
 target_link_libraries(wiringx-interrupt wiringx_shared pthread)
 target_link_libraries(wiringx-read wiringx_shared)
+target_link_libraries(wiringx-pwm wiringx_shared)
 
 install(FILES ${CMAKE_BINARY_DIR}/libwiringX.so DESTINATION lib/ COMPONENT library)
 install(FILES ${CMAKE_BINARY_DIR}/libwiringX.a DESTINATION lib/ COMPONENT library)
@@ -127,6 +132,7 @@ install(FILES ${PROJECT_SOURCE_DIR}/src/wiringX.h DESTINATION include/ COMPONENT
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-blink DESTINATION sbin/ COMPONENT library)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-interrupt DESTINATION sbin/ COMPONENT library)
 install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-read DESTINATION sbin/ COMPONENT library)
+install(PROGRAMS ${CMAKE_BINARY_DIR}/wiringx-pwm DESTINATION sbin/ COMPONENT library)
 
 WRITE_UNINSTALL_TARGET_SCRIPT()
 configure_file("${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake.in"

--- a/examples/pwm.c
+++ b/examples/pwm.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include "wiringX.h"
+
+char *usage =
+	"Usage: %s PLATTFORM GPIO CLOCK RANGE VALUE\n"
+	"       GPIO to set PWM\n"
+	"       CLOCK clock frequency in Hz\n"
+	"       RANGE set maximum range for VALUE\n"
+	"       VALUE pwm value\n"
+	"Example: %s raspberrypi1b2 1 100000 256 128\n";
+
+int main(int argc, char *argv[]) {
+	char *str = NULL;
+	char usagestr[160];
+	int gpio = 0;
+	int range = 0;
+	int clock = 0;
+	int value = 0;
+	int i;
+	bool invalid = false;
+
+	memset(usagestr, '\0', 160);
+
+	// expect 5 arguments
+	if(argc != 6) {
+		snprintf(usagestr, 159, usage, argv[0], argv[0]);
+		puts(usagestr);
+		return -1;
+	}
+	// check for a valid, numeric argument
+	for(i = 2; i <= 5; i++) {
+		str = argv[i];
+		while(*str != '\0') {
+			if(!isdigit(*str)) {
+				invalid = true;
+			}
+			str++;
+		}
+		if(invalid) {
+			printf("%s: Invalid GPIO %s\n", argv[0], argv[1]);
+			return -1;
+		}
+	}
+
+	gpio = atoi(argv[2]);
+	clock = atoi(argv[3]);
+	range = atoi(argv[4]);
+	value = atoi(argv[5]);
+
+	if (wiringXSetup(argv[1], NULL) != 0) {
+		exit(-1);
+	}
+
+	if (pinMode(gpio, PINMODE_PWM_OUTPUT) != 0) {
+		exit(-1);
+	}
+
+	if (wiringXPwmSetClock(gpio, clock) != 0) {
+		exit(-1);
+	}
+	if (wiringXPwmSetRange(gpio, range) != 0) {
+		exit(-1);
+	}
+	if (wiringXPwmWrite(gpio, value) != 0) {
+		exit(-1);
+	}
+}

--- a/src/platform/lemaker/bananapi1.c
+++ b/src/platform/lemaker/bananapi1.c
@@ -81,6 +81,9 @@ void bananapi1Init(void) {
 
 	bananapi1->digitalRead = bananapi1->soc->digitalRead;
 	bananapi1->digitalWrite = bananapi1->soc->digitalWrite;
+	bananapi1->pwmSetClock = bananapi1->soc->pwmSetClock;
+	bananapi1->pwmSetRange = bananapi1->soc->pwmSetRange;
+	bananapi1->pwmWrite = bananapi1->soc->pwmWrite;
 	bananapi1->pinMode = bananapi1->soc->pinMode;
 	bananapi1->setup = &bananapi1Setup;
 

--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -42,6 +42,9 @@ void platform_register(struct platform_t **platform, char *name) {
 	(*platform)->waitForInterrupt = NULL;
 	(*platform)->isr = NULL;
 	(*platform)->selectableFd = NULL;
+	(*platform)->pwmSetClock = NULL;
+	(*platform)->pwmSetRange = NULL;
+	(*platform)->pwmWrite = NULL;
 	(*platform)->validGPIO = NULL;
 	(*platform)->gc = NULL;
 	

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -10,6 +10,7 @@
 #define __WIRINGX_PLATFORM_H_
 
 #include <limits.h>
+#include <stdint.h>
 
 #include "../wiringX.h"
 #include "../soc/soc.h"
@@ -28,7 +29,9 @@ typedef struct platform_t {
 	int (*waitForInterrupt)(int, int);
 	int (*isr)(int, enum isr_mode_t);
 	int (*selectableFd)(int);
-
+	int (*pwmSetClock)(int pin, uint32_t frequency);
+	int (*pwmSetRange)(int pin, uint32_t val);
+	int (*pwmWrite)(int pin, uint32_t val);
 	int (*validGPIO)(int);
 	int (*gc)(void);
 	

--- a/src/platform/raspberrypi/raspberrypi1b+.c
+++ b/src/platform/raspberrypi/raspberrypi1b+.c
@@ -73,6 +73,9 @@ void raspberrypi1bpInit(void) {
 	raspberrypi1bp->isr = raspberrypi1bp->soc->isr;
 	raspberrypi1bp->waitForInterrupt = raspberrypi1bp->soc->waitForInterrupt;
 
+	raspberrypi1bp->pwmSetClock = raspberrypi1bp->soc->pwmSetClock;
+	raspberrypi1bp->pwmSetRange = raspberrypi1bp->soc->pwmSetRange;
+	raspberrypi1bp->pwmWrite = raspberrypi1bp->soc->pwmWrite;
 	raspberrypi1bp->selectableFd = raspberrypi1bp->soc->selectableFd;
 	raspberrypi1bp->gc = raspberrypi1bp->soc->gc;
 

--- a/src/platform/raspberrypi/raspberrypi1b1.c
+++ b/src/platform/raspberrypi/raspberrypi1b1.c
@@ -65,6 +65,9 @@ void raspberrypi1b1Init(void) {
 	raspberrypi1b1->isr = raspberrypi1b1->soc->isr;
 	raspberrypi1b1->waitForInterrupt = raspberrypi1b1->soc->waitForInterrupt;
 
+	raspberrypi1b1->pwmSetClock = raspberrypi1b1->soc->pwmSetClock;
+	raspberrypi1b1->pwmSetRange = raspberrypi1b1->soc->pwmSetRange;
+	raspberrypi1b1->pwmWrite = raspberrypi1b1->soc->pwmWrite;
 	raspberrypi1b1->selectableFd = raspberrypi1b1->soc->selectableFd;
 	raspberrypi1b1->gc = raspberrypi1b1->soc->gc;
 

--- a/src/platform/raspberrypi/raspberrypi1b2.c
+++ b/src/platform/raspberrypi/raspberrypi1b2.c
@@ -67,6 +67,9 @@ void raspberrypi1b2Init(void) {
 	raspberrypi1b2->isr = raspberrypi1b2->soc->isr;
 	raspberrypi1b2->waitForInterrupt = raspberrypi1b2->soc->waitForInterrupt;
 
+	raspberrypi1b2->pwmSetClock = raspberrypi1b2->soc->pwmSetClock;
+	raspberrypi1b2->pwmSetRange = raspberrypi1b2->soc->pwmSetRange;
+	raspberrypi1b2->pwmWrite = raspberrypi1b2->soc->pwmWrite;
 	raspberrypi1b2->selectableFd = raspberrypi1b2->soc->selectableFd;
 	raspberrypi1b2->gc = raspberrypi1b2->soc->gc;
 

--- a/src/platform/raspberrypi/raspberrypi2.c
+++ b/src/platform/raspberrypi/raspberrypi2.c
@@ -78,5 +78,8 @@ void raspberrypi2Init(void) {
 	raspberrypi2->gc = raspberrypi2->soc->gc;
 
 	raspberrypi2->validGPIO = &raspberrypi2ValidGPIO;
+	raspberrypi2->pwmSetClock = raspberrypi2->soc->pwmSetClock;
+	raspberrypi2->pwmSetRange = raspberrypi2->soc->pwmSetRange;
+	raspberrypi2->pwmWrite = raspberrypi2->soc->pwmWrite;
 
 }

--- a/src/platform/raspberrypi/raspberrypi3.c
+++ b/src/platform/raspberrypi/raspberrypi3.c
@@ -83,4 +83,7 @@ void raspberrypi3Init(void) {
 	raspberrypi3->gc = raspberrypi3->soc->gc;
 
 	raspberrypi3->validGPIO = &raspberrypi3ValidGPIO;
+	raspberrypi3->pwmSetClock = raspberrypi3->soc->pwmSetClock;
+	raspberrypi3->pwmSetRange = raspberrypi3->soc->pwmSetRange;
+	raspberrypi3->pwmWrite = raspberrypi3->soc->pwmWrite;
 }

--- a/src/soc/allwinner/a10.c
+++ b/src/soc/allwinner/a10.c
@@ -21,6 +21,34 @@
 
 struct soc_t *allwinnerA10 = NULL;
 
+enum functionselect_t {
+	GPIO_INPUT = 0b000,
+	GPIO_OUTPUT = 0b001,
+	GPIO_ALT2 = 0b010,
+	GPIO_ALT3 = 0b011,
+	GPIO_ALT4 = 0b100,
+	GPIO_ALT5 = 0b101,
+	GPIO_UNDEF = -1
+};
+
+enum pwm_channel_t {
+	PWM_CHANNEL0,
+	PWM_CHANNEL1,
+	PWM_NOCHANNEL
+};
+
+#define PWM_CTRL_REG	0x0E00
+#define PWM_CH0_PERIOD	0x0E04
+#define PWM_CH1_PERIOD	0x0E08
+
+#define PWM_CHAN_MASK		0x1ff
+#define PWM_PRESCALE_MASK	0x00f
+#define PWM_EN 				(1 << 4)
+#define PWM_ACT_STA			(1 << 5)
+#define PWM_SCLK_CH_GATING	(1 << 6)
+#define PWM_MS_MODE			(1 << 7)
+#define PWM_PUL_STA			(1 << 8)
+
 static struct layout_t {
 	char *name;
 
@@ -36,6 +64,11 @@ static struct layout_t {
 		unsigned long bit;
 	} data;
 
+	struct {
+		enum functionselect_t alt_mode;
+		enum pwm_channel_t pwm_channel;
+	} pwm;
+
 	int support;
 
 	enum pinmode_t mode;
@@ -43,177 +76,180 @@ static struct layout_t {
 	int fd;
 
 } layout[] = {
- { "PA0", 0, { 0x00, 0 }, { 0x10, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA1", 0, { 0x00, 4 }, { 0x10, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA2", 0, { 0x00, 8 }, { 0x10, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA3", 0, { 0x00, 12 }, { 0x10, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA4", 0, { 0x00, 16 }, { 0x10, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA5", 0, { 0x00, 20 }, { 0x10, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA6", 0, { 0x00, 24 }, { 0x10, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA7", 0, { 0x00, 28 }, { 0x10, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA8", 0, { 0x04, 0 }, { 0x10, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA9", 0, { 0x04, 4 }, { 0x10, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA10", 0, { 0x04, 8 }, { 0x10, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA11", 0, { 0x04, 12 }, { 0x10, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA12", 0, { 0x04, 16 }, { 0x10, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA13", 0, { 0x04, 20 }, { 0x10, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA14", 0, { 0x04, 24 }, { 0x10, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA15", 0, { 0x04, 28 }, { 0x10, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA16", 0, { 0x08, 0 }, { 0x10, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PA17", 0, { 0x08, 4 }, { 0x10, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB0", 0, { 0x24, 0 }, { 0x34, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB1", 0, { 0x24, 4 }, { 0x34, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB2", 0, { 0x24, 8 }, { 0x34, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB3", 0, { 0x24, 12 }, { 0x34, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB4", 0, { 0x24, 16 }, { 0x34, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB5", 0, { 0x24, 20 }, { 0x34, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB6", 0, { 0x24, 24 }, { 0x34, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB7", 0, { 0x24, 28 }, { 0x34, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB8", 0, { 0x28, 0 }, { 0x34, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB9", 0, { 0x28, 4 }, { 0x34, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB10", 0, { 0x28, 8 }, { 0x34, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB11", 0, { 0x28, 12 }, { 0x34, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB12", 0, { 0x28, 16 }, { 0x34, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB13", 0, { 0x28, 20 }, { 0x34, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB14", 0, { 0x28, 24 }, { 0x34, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB15", 0, { 0x28, 28 }, { 0x34, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB16", 0, { 0x32, 0 }, { 0x34, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB17", 0, { 0x32, 4 }, { 0x34, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB18", 0, { 0x32, 8 }, { 0x34, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB19", 0, { 0x32, 12 }, { 0x34, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB20", 0, { 0x32, 16 }, { 0x34, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB21", 0, { 0x32, 20 }, { 0x34, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB22", 0, { 0x32, 24 }, { 0x34, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PB23", 0, { 0x32, 28 }, { 0x34, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC0", 0, { 0x48, 0 }, { 0x58, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC1", 0, { 0x48, 4 }, { 0x58, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC2", 0, { 0x48, 8 }, { 0x58, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC3", 0, { 0x48, 12 }, { 0x58, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC4", 0, { 0x48, 16 }, { 0x58, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC5", 0, { 0x48, 20 }, { 0x58, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC6", 0, { 0x48, 24 }, { 0x58, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC7", 0, { 0x48, 28 }, { 0x58, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC8", 0, { 0x4C, 0 }, { 0x58, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC9", 0, { 0x4C, 4 }, { 0x58, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC10", 0, { 0x4C, 8 }, { 0x58, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC11", 0, { 0x4C, 12 }, { 0x58, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC12", 0, { 0x4C, 16 }, { 0x58, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC13", 0, { 0x4C, 20 }, { 0x58, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC14", 0, { 0x4C, 24 }, { 0x58, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC15", 0, { 0x4C, 28 }, { 0x58, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC16", 0, { 0x50, 0 }, { 0x58, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC17", 0, { 0x50, 4 }, { 0x58, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC18", 0, { 0x50, 8 }, { 0x58, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC19", 0, { 0x50, 12 }, { 0x58, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC20", 0, { 0x50, 16 }, { 0x58, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC21", 0, { 0x50, 20 }, { 0x58, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC22", 0, { 0x50, 24 }, { 0x58, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PC23", 0, { 0x50, 28 }, { 0x58, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD0", 0, { 0x6C, 0 }, { 0x7C, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD1", 0, { 0x6C, 4 }, { 0x7C, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD2", 0, { 0x6C, 8 }, { 0x7C, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD3", 0, { 0x6C, 12 }, { 0x7C, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD4", 0, { 0x6C, 16 }, { 0x7C, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD5", 0, { 0x6C, 20 }, { 0x7C, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD6", 0, { 0x6C, 24 }, { 0x7C, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD7", 0, { 0x6C, 28 }, { 0x7C, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD8", 0, { 0x70, 0 }, { 0x7C, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD9", 0, { 0x70, 4 }, { 0x7C, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD10", 0, { 0x70, 8 }, { 0x7C, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD11", 0, { 0x70, 12 }, { 0x7C, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD12", 0, { 0x70, 16 }, { 0x7C, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD13", 0, { 0x70, 20 }, { 0x7C, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD14", 0, { 0x70, 24 }, { 0x7C, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD15", 0, { 0x70, 28 }, { 0x7C, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD16", 0, { 0x74, 0 }, { 0x7C, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD17", 0, { 0x74, 4 }, { 0x7C, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD18", 0, { 0x74, 8 }, { 0x7C, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD19", 0, { 0x74, 12 }, { 0x7C, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD20", 0, { 0x74, 16 }, { 0x7C, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD21", 0, { 0x74, 20 }, { 0x7C, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD22", 0, { 0x74, 24 }, { 0x7C, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD23", 0, { 0x74, 28 }, { 0x7C, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD24", 0, { 0x78, 0 }, { 0x7C, 24 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD25", 0, { 0x78, 4 }, { 0x7C, 25 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD26", 0, { 0x78, 8 }, { 0x7C, 26 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PD27", 0, { 0x78, 12 }, { 0x7C, 27 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE0", 0, { 0x90, 0 }, { 0xA0, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE1", 0, { 0x90, 4 }, { 0xA0, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE2", 0, { 0x90, 8 }, { 0xA0, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE3", 0, { 0x90, 12 }, { 0xA0, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE4", 0, { 0x90, 16 }, { 0xA0, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE5", 0, { 0x90, 20 }, { 0xA0, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE6", 0, { 0x90, 24 }, { 0xA0, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE7", 0, { 0x90, 28 }, { 0xA0, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE8", 0, { 0x94, 0 }, { 0xA0, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE9", 0, { 0x94, 4 }, { 0xA0, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE10", 0, { 0x94, 8 }, { 0xA0, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PE11", 0, { 0x94, 12 }, { 0xA0, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF0", 0, { 0xB4, 0 }, { 0xC4, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF1", 0, { 0xB4, 4 }, { 0xC4, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF2", 0, { 0xB4, 8 }, { 0xC4, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF3", 0, { 0xB4, 12 }, { 0xC4, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF4", 0, { 0xB4, 16 }, { 0xC4, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PF5", 0, { 0xB4, 20 }, { 0xC4, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG0", 0, { 0xDC, 0 }, { 0xE8, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG1", 0, { 0xDC, 4 }, { 0xE8, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG2", 0, { 0xDC, 8 }, { 0xE8, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG3", 0, { 0xDC, 12 }, { 0xE8, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG4", 0, { 0xDC, 16 }, { 0xE8, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG5", 0, { 0xDC, 20 }, { 0xE8, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG6", 0, { 0xDC, 24 }, { 0xE8, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG7", 0, { 0xDC, 28 }, { 0xE8, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG8", 0, { 0xE0, 0 }, { 0xE8, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG9", 0, { 0xE0, 4 }, { 0xE8, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG10", 0, { 0xE0, 8 }, { 0xE8, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PG11", 0, { 0xE0, 12 }, { 0xE8, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH0", 0, { 0xFC, 0 }, { 0x10C, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH1", 0, { 0xFC, 4 }, { 0x10C, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH2", 0, { 0xFC, 8 }, { 0x10C, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH3", 0, { 0xFC, 12 }, { 0x10C, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH4", 0, { 0xFC, 16 }, { 0x10C, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH5", 0, { 0xFC, 20 }, { 0x10C, 5 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH6", 0, { 0xFC, 24 }, { 0x10C, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH7", 0, { 0xFC, 28 }, { 0x10C, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH8", 0, { 0x100, 0 }, { 0x10C, 8 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH9", 0, { 0x100, 4 }, { 0x10C, 9 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH10", 0, { 0x100, 8 }, { 0x10C, 10 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH11", 0, { 0x100, 12 }, { 0x10C, 11 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH12", 0, { 0x100, 16 }, { 0x10C, 12 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH13", 0, { 0x100, 20 }, { 0x10C, 13 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH14", 0, { 0x100, 24 }, { 0x10C, 14 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PH15", 0, { 0x100, 28 }, { 0x10C, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH16", 0, { 0x104, 0 }, { 0x10C, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH17", 0, { 0x104, 4 }, { 0x10C, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH18", 0, { 0x104, 8 }, { 0x10C, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH19", 0, { 0x104, 12 }, { 0x10C, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH20", 0, { 0x104, 16 }, { 0x10C, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH21", 0, { 0x104, 20 }, { 0x10C, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH22", 0, { 0x104, 24 }, { 0x10C, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PH23", 0, { 0x104, 28 }, { 0x10C, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI0", 0, { 0x120, 0 }, { 0x130, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI1", 0, { 0x120, 4 }, { 0x130, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI2", 0, { 0x120, 8 }, { 0x130, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI3", 0, { 0x120, 12 }, { 0x130, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI4", 0, { 0x120, 16 }, { 0x130, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI5", 0, { 0x120, 20 }, { 0x130, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI6", 0, { 0x120, 24 }, { 0x130, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI7", 0, { 0x124, 28 }, { 0x130, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI8", 0, { 0x124, 0 }, { 0x130, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI9", 0, { 0x124, 4 }, { 0x130, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI10", 0, { 0x124, 8 }, { 0x130, 10 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PI11", 0, { 0x124, 12 }, { 0x130, 11 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PI12", 0, { 0x124, 16 }, { 0x130, 12 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PI13", 0, { 0x124, 20 }, { 0x130, 13 }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
- { "PI14", 0, { 0x124, 24 }, { 0x130, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI15", 0, { 0x128, 28 }, { 0x130, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI16", 0, { 0x128, 0 }, { 0x130, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI17", 0, { 0x128, 4 }, { 0x130, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI18", 0, { 0x128, 8 }, { 0x130, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI19", 0, { 0x128, 12 }, { 0x130, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI20", 0, { 0x128, 16 }, { 0x130, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
- { "PI21", 0, { 0x128, 20 }, { 0x130, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 }
+ { "PA0", 0, { 0x00, 0 }, { 0x10, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA1", 0, { 0x00, 4 }, { 0x10, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA2", 0, { 0x00, 8 }, { 0x10, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA3", 0, { 0x00, 12 }, { 0x10, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA4", 0, { 0x00, 16 }, { 0x10, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA5", 0, { 0x00, 20 }, { 0x10, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA6", 0, { 0x00, 24 }, { 0x10, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA7", 0, { 0x00, 28 }, { 0x10, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA8", 0, { 0x04, 0 }, { 0x10, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA9", 0, { 0x04, 4 }, { 0x10, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA10", 0, { 0x04, 8 }, { 0x10, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA11", 0, { 0x04, 12 }, { 0x10, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA12", 0, { 0x04, 16 }, { 0x10, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA13", 0, { 0x04, 20 }, { 0x10, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA14", 0, { 0x04, 24 }, { 0x10, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA15", 0, { 0x04, 28 }, { 0x10, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA16", 0, { 0x08, 0 }, { 0x10, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PA17", 0, { 0x08, 4 }, { 0x10, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB0", 0, { 0x24, 0 }, { 0x34, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB1", 0, { 0x24, 4 }, { 0x34, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB2", 0, { 0x24, 8 }, { 0x34, 2 }, { GPIO_ALT2, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB3", 0, { 0x24, 12 }, { 0x34, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB4", 0, { 0x24, 16 }, { 0x34, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB5", 0, { 0x24, 20 }, { 0x34, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB6", 0, { 0x24, 24 }, { 0x34, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB7", 0, { 0x24, 28 }, { 0x34, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB8", 0, { 0x28, 0 }, { 0x34, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB9", 0, { 0x28, 4 }, { 0x34, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB10", 0, { 0x28, 8 }, { 0x34, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB11", 0, { 0x28, 12 }, { 0x34, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB12", 0, { 0x28, 16 }, { 0x34, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB13", 0, { 0x28, 20 }, { 0x34, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB14", 0, { 0x28, 24 }, { 0x34, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB15", 0, { 0x28, 28 }, { 0x34, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB16", 0, { 0x32, 0 }, { 0x34, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB17", 0, { 0x32, 4 }, { 0x34, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB18", 0, { 0x32, 8 }, { 0x34, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB19", 0, { 0x32, 12 }, { 0x34, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB20", 0, { 0x32, 16 }, { 0x34, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB21", 0, { 0x32, 20 }, { 0x34, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB22", 0, { 0x32, 24 }, { 0x34, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PB23", 0, { 0x32, 28 }, { 0x34, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC0", 0, { 0x48, 0 }, { 0x58, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC1", 0, { 0x48, 4 }, { 0x58, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC2", 0, { 0x48, 8 }, { 0x58, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC3", 0, { 0x48, 12 }, { 0x58, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC4", 0, { 0x48, 16 }, { 0x58, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC5", 0, { 0x48, 20 }, { 0x58, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC6", 0, { 0x48, 24 }, { 0x58, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC7", 0, { 0x48, 28 }, { 0x58, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC8", 0, { 0x4C, 0 }, { 0x58, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC9", 0, { 0x4C, 4 }, { 0x58, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC10", 0, { 0x4C, 8 }, { 0x58, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC11", 0, { 0x4C, 12 }, { 0x58, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC12", 0, { 0x4C, 16 }, { 0x58, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC13", 0, { 0x4C, 20 }, { 0x58, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC14", 0, { 0x4C, 24 }, { 0x58, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC15", 0, { 0x4C, 28 }, { 0x58, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC16", 0, { 0x50, 0 }, { 0x58, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC17", 0, { 0x50, 4 }, { 0x58, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC18", 0, { 0x50, 8 }, { 0x58, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC19", 0, { 0x50, 12 }, { 0x58, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC20", 0, { 0x50, 16 }, { 0x58, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC21", 0, { 0x50, 20 }, { 0x58, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC22", 0, { 0x50, 24 }, { 0x58, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PC23", 0, { 0x50, 28 }, { 0x58, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD0", 0, { 0x6C, 0 }, { 0x7C, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD1", 0, { 0x6C, 4 }, { 0x7C, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD2", 0, { 0x6C, 8 }, { 0x7C, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD3", 0, { 0x6C, 12 }, { 0x7C, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD4", 0, { 0x6C, 16 }, { 0x7C, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD5", 0, { 0x6C, 20 }, { 0x7C, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD6", 0, { 0x6C, 24 }, { 0x7C, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD7", 0, { 0x6C, 28 }, { 0x7C, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD8", 0, { 0x70, 0 }, { 0x7C, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD9", 0, { 0x70, 4 }, { 0x7C, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD10", 0, { 0x70, 8 }, { 0x7C, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD11", 0, { 0x70, 12 }, { 0x7C, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD12", 0, { 0x70, 16 }, { 0x7C, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD13", 0, { 0x70, 20 }, { 0x7C, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD14", 0, { 0x70, 24 }, { 0x7C, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD15", 0, { 0x70, 28 }, { 0x7C, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD16", 0, { 0x74, 0 }, { 0x7C, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD17", 0, { 0x74, 4 }, { 0x7C, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD18", 0, { 0x74, 8 }, { 0x7C, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD19", 0, { 0x74, 12 }, { 0x7C, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD20", 0, { 0x74, 16 }, { 0x7C, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD21", 0, { 0x74, 20 }, { 0x7C, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD22", 0, { 0x74, 24 }, { 0x7C, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD23", 0, { 0x74, 28 }, { 0x7C, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD24", 0, { 0x78, 0 }, { 0x7C, 24 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD25", 0, { 0x78, 4 }, { 0x7C, 25 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD26", 0, { 0x78, 8 }, { 0x7C, 26 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PD27", 0, { 0x78, 12 }, { 0x7C, 27 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE0", 0, { 0x90, 0 }, { 0xA0, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE1", 0, { 0x90, 4 }, { 0xA0, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE2", 0, { 0x90, 8 }, { 0xA0, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE3", 0, { 0x90, 12 }, { 0xA0, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE4", 0, { 0x90, 16 }, { 0xA0, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE5", 0, { 0x90, 20 }, { 0xA0, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE6", 0, { 0x90, 24 }, { 0xA0, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE7", 0, { 0x90, 28 }, { 0xA0, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE8", 0, { 0x94, 0 }, { 0xA0, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE9", 0, { 0x94, 4 }, { 0xA0, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE10", 0, { 0x94, 8 }, { 0xA0, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PE11", 0, { 0x94, 12 }, { 0xA0, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF0", 0, { 0xB4, 0 }, { 0xC4, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF1", 0, { 0xB4, 4 }, { 0xC4, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF2", 0, { 0xB4, 8 }, { 0xC4, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF3", 0, { 0xB4, 12 }, { 0xC4, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF4", 0, { 0xB4, 16 }, { 0xC4, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PF5", 0, { 0xB4, 20 }, { 0xC4, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG0", 0, { 0xDC, 0 }, { 0xE8, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG1", 0, { 0xDC, 4 }, { 0xE8, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG2", 0, { 0xDC, 8 }, { 0xE8, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG3", 0, { 0xDC, 12 }, { 0xE8, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG4", 0, { 0xDC, 16 }, { 0xE8, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG5", 0, { 0xDC, 20 }, { 0xE8, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG6", 0, { 0xDC, 24 }, { 0xE8, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG7", 0, { 0xDC, 28 }, { 0xE8, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG8", 0, { 0xE0, 0 }, { 0xE8, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG9", 0, { 0xE0, 4 }, { 0xE8, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG10", 0, { 0xE0, 8 }, { 0xE8, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PG11", 0, { 0xE0, 12 }, { 0xE8, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH0", 0, { 0xFC, 0 }, { 0x10C, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH1", 0, { 0xFC, 4 }, { 0x10C, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH2", 0, { 0xFC, 8 }, { 0x10C, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH3", 0, { 0xFC, 12 }, { 0x10C, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH4", 0, { 0xFC, 16 }, { 0x10C, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH5", 0, { 0xFC, 20 }, { 0x10C, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH6", 0, { 0xFC, 24 }, { 0x10C, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH7", 0, { 0xFC, 28 }, { 0x10C, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH8", 0, { 0x100, 0 }, { 0x10C, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH9", 0, { 0x100, 4 }, { 0x10C, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH10", 0, { 0x100, 8 }, { 0x10C, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH11", 0, { 0x100, 12 }, { 0x10C, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH12", 0, { 0x100, 16 }, { 0x10C, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH13", 0, { 0x100, 20 }, { 0x10C, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH14", 0, { 0x100, 24 }, { 0x10C, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PH15", 0, { 0x100, 28 }, { 0x10C, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH16", 0, { 0x104, 0 }, { 0x10C, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH17", 0, { 0x104, 4 }, { 0x10C, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH18", 0, { 0x104, 8 }, { 0x10C, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH19", 0, { 0x104, 12 }, { 0x10C, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH20", 0, { 0x104, 16 }, { 0x10C, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH21", 0, { 0x104, 20 }, { 0x10C, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH22", 0, { 0x104, 24 }, { 0x10C, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PH23", 0, { 0x104, 28 }, { 0x10C, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI0", 0, { 0x120, 0 }, { 0x130, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI1", 0, { 0x120, 4 }, { 0x130, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI2", 0, { 0x120, 8 }, { 0x130, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI3", 0, { 0x120, 12 }, { 0x130, 3 }, { GPIO_ALT2, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI4", 0, { 0x120, 16 }, { 0x130, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI5", 0, { 0x120, 20 }, { 0x130, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI6", 0, { 0x120, 24 }, { 0x130, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI7", 0, { 0x124, 28 }, { 0x130, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI8", 0, { 0x124, 0 }, { 0x130, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI9", 0, { 0x124, 4 }, { 0x130, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI10", 0, { 0x124, 8 }, { 0x130, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PI11", 0, { 0x124, 12 }, { 0x130, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PI12", 0, { 0x124, 16 }, { 0x130, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PI13", 0, { 0x124, 20 }, { 0x130, 13 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL | FUNCTION_INTERRUPT, PINMODE_NOT_SET, 0 },
+ { "PI14", 0, { 0x124, 24 }, { 0x130, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI15", 0, { 0x128, 28 }, { 0x130, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI16", 0, { 0x128, 0 }, { 0x130, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI17", 0, { 0x128, 4 }, { 0x130, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI18", 0, { 0x128, 8 }, { 0x130, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI19", 0, { 0x128, 12 }, { 0x130, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI20", 0, { 0x128, 16 }, { 0x130, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+ { "PI21", 0, { 0x128, 20 }, { 0x130, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 }
 };
+
+static uint32_t pwm_frequency = 100000;
+static uint32_t pwm_range = 1024;
 
 static int allwinnerA10Setup(void) {
 	if((allwinnerA10->fd = open("/dev/mem", O_RDWR | O_SYNC )) < 0) {
@@ -221,8 +257,9 @@ static int allwinnerA10Setup(void) {
 		return -1;
 	}
 
-	if((allwinnerA10->gpio[0] = (unsigned char *)mmap(0, allwinnerA10->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, allwinnerA10->fd, allwinnerA10->base_addr[0])) == NULL) {
-		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s GPIO memory address", allwinnerA10->brand, allwinnerA10->chip);
+	if((allwinnerA10->gpio[0] = (unsigned char *)mmap(0, allwinnerA10->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, allwinnerA10->fd, allwinnerA10->base_addr[0])) == MAP_FAILED) {
+		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s GPIO memory address: %s",
+				allwinnerA10->brand, allwinnerA10->chip, strerror(errno));
 		return -1;
 	}
 
@@ -300,8 +337,161 @@ static int allwinnerA10DigitalRead(int i) {
 	return (int)((val & (1 << pin->data.bit)) >> pin->data.bit);
 }
 
-static int allwinnerA10PinMode(int i, enum pinmode_t mode) {
-	struct layout_t *pin = NULL;
+// The clock frequency is 24MHz, but only fixed dividers are available for the
+// base clock. The clock has also be divided by the pwm range, so the range
+// depends also on the used range.
+//
+// A useful range would be 50kHz to 500Hz. The A20 supports
+// setting the frequency per channel
+
+static int allwinnerA10PwmSetClock (int pin, uint32_t frequency)
+{
+	struct layout_t *pinlayout = &allwinnerA10->layout[allwinnerA10->map[pin]];
+	uint32_t val = 0;
+	uint32_t mask = 0;
+	uint32_t shift = 0;
+	uint32_t divisor = 0;
+	unsigned long pwm_ctl_addr = ((unsigned long) allwinnerA10->gpio[0]) + PWM_CTRL_REG;
+
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		shift = 0;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		shift = 15;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel configuration %d for pin %d %s",
+					pinlayout->pwm.pwm_channel, pin, pinlayout->name);
+		return -1;
+	}
+	pwm_frequency = frequency;
+
+	frequency = frequency * pwm_range;
+
+	// Get nearest frequency supported by divisor
+	if (frequency > 200000) {
+		divisor = 0;
+	} else if (frequency > 133333) {
+		divisor = 1;
+	} else if (frequency > 100000) {
+		divisor = 2;
+	} else if (frequency > 66666) {
+		divisor = 3;
+	} else if (frequency > 50000) {
+		divisor = 4;
+	} else if (frequency > 2000) {
+		divisor = 0x10;
+	} else if (frequency > 1000) {
+		divisor = 0x11;
+	} else if (frequency > 666) {
+		divisor = 0x12;
+	} else if (frequency > 500) {
+		divisor = 0x13;
+	} else {
+		divisor = 0x14;
+	}
+
+	mask = (PWM_PRESCALE_MASK | PWM_EN | PWM_SCLK_CH_GATING | PWM_ACT_STA) << shift;
+	divisor = divisor << shift;
+	val = soc_readl(pwm_ctl_addr);
+	val &= ~mask;
+	val |= divisor;
+	soc_writel(pwm_ctl_addr, val);
+
+	return 0;
+}
+
+static int allwinnerA10PwmWrite(int pin, uint32_t pwmval) {
+	struct layout_t *pinlayout = &allwinnerA10->layout[allwinnerA10->map[pin]];
+
+	unsigned long pwm_period_addr = ((unsigned long) allwinnerA10->gpio[0]);
+	int shift;
+	uint32_t val;
+
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		pwm_period_addr += PWM_CH0_PERIOD;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		pwm_period_addr += PWM_CH1_PERIOD;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel configuration %d for pin %d %s",
+					pinlayout->pwm.pwm_channel, pin, pinlayout->name);
+		return -1;
+	}
+
+	pwmval &= 0xffff; //set max period to 2^16
+	val = soc_readl(pwm_period_addr);
+	val &=0xffff0000;
+	val |= pwmval;
+	soc_writel(pwm_period_addr, val);
+
+	return 0;
+}
+
+// Enable a PWM channel
+static int allwinnerA10PwmEnableChannel(enum pwm_channel_t channel) {
+	uint32_t val = 0;
+	uint32_t enable = PWM_EN | PWM_SCLK_CH_GATING | PWM_ACT_STA;
+	int shift;
+
+	unsigned long pwm_ctl_addr = ((unsigned long) allwinnerA10->gpio[0]) + PWM_CTRL_REG;
+	if (channel == PWM_CHANNEL0) {
+		shift = 0;
+	} else if (channel == PWM_CHANNEL1) {
+		shift = 15;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel %d", channel);
+		return -1;
+	}
+
+	enable = enable << shift;
+	val = soc_readl(pwm_ctl_addr);
+	val |= enable;
+	soc_writel(pwm_ctl_addr, val);
+	return 0;
+}
+
+static int allwinnerA10PwmSetRange(int pin, uint32_t range) {
+	struct layout_t *pinlayout = &allwinnerA10->layout[allwinnerA10->map[pin]];
+
+	unsigned long pwm_period_addr = ((unsigned long) allwinnerA10->gpio[0]);
+	int shift;
+	uint32_t val;
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		pwm_period_addr += PWM_CH0_PERIOD;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		pwm_period_addr += PWM_CH1_PERIOD;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel configuration %d for pin %d %s",
+					pinlayout->pwm.pwm_channel, pin, pinlayout->name);
+		return -1;
+	}
+
+	range &= 0xffff; //set max period to 2^16
+	pwm_range = range;
+	allwinnerA10PwmSetClock(pin, pwm_frequency);
+
+	range = range << 16;
+	val = soc_readl(pwm_period_addr);
+	val &=0x0000ffff;
+	val |= range;
+	soc_writel(pwm_period_addr, val);
+	allwinnerA10PwmEnableChannel(pinlayout->pwm.pwm_channel);
+
+	return 0;
+}
+
+static void allwinnerA10FunctionSelect(unsigned long addr, struct layout_t *pin,
+									   enum functionselect_t fsel) {
+	uint32_t val = soc_readl(addr);
+	uint32_t mask = 0b111;
+	uint32_t sel = fsel;
+	mask = mask << pin->select.bit;
+	sel = sel << pin->select.bit;
+	val &= ~mask;
+	val |= sel;
+	soc_writel(addr, val);
+}
+
+static int allwinnerA10PinMode(int pin, enum pinmode_t mode) {
+	struct layout_t *pinlayout = NULL;
 	unsigned long addr = 0;
 	uint32_t val = 0;
 
@@ -314,23 +504,42 @@ static int allwinnerA10PinMode(int i, enum pinmode_t mode) {
 		return -1;
 	}
 
-	pin = &allwinnerA10->layout[allwinnerA10->map[i]];
-	addr = (unsigned long)(allwinnerA10->gpio[pin->addr] + allwinnerA10->base_offs[pin->addr] + pin->select.offset);
-	pin->mode = mode;
+	pinlayout = &allwinnerA10->layout[allwinnerA10->map[pin]];
+	addr = (unsigned long)(allwinnerA10->gpio[pinlayout->addr] + allwinnerA10->base_offs[pinlayout->addr] + pinlayout->select.offset);
 
-	val = soc_readl(addr);
-	if(mode == PINMODE_OUTPUT) {
-		val |= (1 << pin->select.bit);
-	} else if(mode == PINMODE_INPUT) {
-		val &= ~(1 << pin->select.bit);
+	switch (mode) {
+	case PINMODE_OUTPUT:
+		allwinnerA10FunctionSelect(addr, pinlayout, GPIO_OUTPUT);
+		pinlayout->mode = PINMODE_OUTPUT;
+		break;
+	case PINMODE_INPUT:
+		allwinnerA10FunctionSelect(addr, pinlayout, GPIO_INPUT);
+		pinlayout->mode = PINMODE_INPUT;
+		break;
+	case PINMODE_PWM_OUTPUT:
+		if (pinlayout->pwm.alt_mode != GPIO_UNDEF) {
+			pinlayout->mode = PINMODE_PWM_OUTPUT;
+			allwinnerA10FunctionSelect(addr, pinlayout, pinlayout->pwm.alt_mode);
+			delayMicroseconds(110);
+			allwinnerA10PwmEnableChannel(pinlayout->pwm.pwm_channel);
+			allwinnerA10PwmSetClock(pin, 100000);
+			allwinnerA10PwmSetRange(pin, 1024);	// Default range of 1024
+			allwinnerA10PwmWrite(pin, 0);
+		} else {
+			wiringXLog(LOG_ERR, "Pin %d (%s) does not support PWM\n", pin,
+					pinlayout->name);
+			pinlayout->mode = PINMODE_NOT_SET;
+		}
+
+		break;
+	default:
+		wiringXLog(LOG_ERR, "Unsupported pin mode %d\n", mode);
+		pinlayout->mode = PINMODE_NOT_SET;
+		return -1;
 	}
-	val &= ~(1 << (pin->select.bit+1));
-	val &= ~(1 << (pin->select.bit+2));
 
-	soc_writel(addr, val);
 	return 0;
 }
-
 
 static int allwinnerA10ISR(int i, enum isr_mode_t mode) {
 	struct layout_t *pin = NULL;
@@ -430,6 +639,7 @@ static int allwinnerA10GC(void) {
 	if(allwinnerA10->gpio[0] != NULL) {
 		munmap(allwinnerA10->gpio[0], allwinnerA10->page_size);
 	} 
+
 	return 0;
 }
 
@@ -473,4 +683,7 @@ void allwinnerA10Init(void) {
 	allwinnerA10->isr = &allwinnerA10ISR;
 	allwinnerA10->waitForInterrupt = &allwinnerA10WaitForInterrupt;
 
+	allwinnerA10->pwmSetClock = &allwinnerA10PwmSetClock;
+	allwinnerA10->pwmSetRange = &allwinnerA10PwmSetRange;
+	allwinnerA10->pwmWrite = &allwinnerA10PwmWrite;
 }

--- a/src/soc/broadcom/2835.c
+++ b/src/soc/broadcom/2835.c
@@ -37,6 +37,56 @@ struct soc_t *broadcom2835 = NULL;
 #define GPLEV0	0x34
 #define GPLEV1	0x38
 
+enum functionselect_t {
+	GPIO_INPUT  = 0b000,
+	GPIO_OUTPUT = 0b001,
+	GPIO_ALT0 = 0b100,
+	GPIO_ALT1 = 0b101,
+	GPIO_ALT2 = 0b110,
+	GPIO_ALT3 = 0b111,
+	GPIO_ALT4 = 0b011,
+	GPIO_ALT5 = 0b010,
+	GPIO_UNDEF      = -1
+};
+
+enum pwm_channel_t {
+	PWM_CHANNEL0,
+	PWM_CHANNEL1,
+	PWM_NOCHANNEL
+};
+
+#define PWM_CLOCK_HZ 19200000
+// PWM Registers
+#define PWM_CTL		0x00
+#define PWM_STA		0x04
+#define PWM_DMAC	0x08
+#define PWM_RNG1	0x10
+#define PWM_DAT1	0x14
+#define PWM_FIF1	0x18
+#define PWM_RNG2	0x20
+#define PWM_DAT2	0x24
+
+#define PWM0_ENABLE		1 << 0  // Channel Enable
+#define PWM0_MSEN		1 << 7
+#define PWM1_ENABLE		1 << 8 // Channel Enable
+#define PWM1_MSEN		1 << 15
+
+#define BCM2836CLK_PASSWORD 0x5A000000
+#define CLK_GP0_CTL 0x70
+#define CLK_GP0_DIV 0x74
+#define CLK_GP1_CTL 0x78
+#define CLK_GP1_DIV 0x7C
+#define CLK_GP2_CTL 0x80
+#define CLK_GP2_DIV 0x84
+
+#define CLK_PCM_CTL 0x98
+#define CLK_PCM_DIV 0x9C
+
+#define CLK_PWM_CTL 0xA0
+#define CLK_PWM_DIV 0xA4
+
+#define CLK_BUSY 0x80
+
 static struct layout_t {
 	char *name;
 
@@ -60,8 +110,12 @@ static struct layout_t {
 	struct {
 		unsigned long offset;
 		unsigned long bit;
-	} level;	
+	} level;
 
+	struct {
+		enum functionselect_t alt_mode;
+		enum pwm_channel_t pwm_channel;
+	} pwm;
 	int support;
 
 	enum pinmode_t mode;
@@ -69,61 +123,64 @@ static struct layout_t {
 	int fd;
 
 } layout[] = {
-	{ "FSEL0", 0, { GPFSEL0, 0 }, { GPSET0, 0 }, { GPCLR0, 0 }, { GPLEV0, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL1", 0, { GPFSEL0, 3 }, { GPSET0, 1 }, { GPCLR0, 1 }, { GPLEV0, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL2", 0, { GPFSEL0, 6 }, { GPSET0, 2 }, { GPCLR0, 2 }, { GPLEV0, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL3", 0, { GPFSEL0, 9 }, { GPSET0, 3 }, { GPCLR0, 3 }, { GPLEV0, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL4", 0, { GPFSEL0, 12 }, { GPSET0, 4 }, { GPCLR0, 4 }, { GPLEV0, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL5", 0, { GPFSEL0, 15 }, { GPSET0, 5 }, { GPCLR0, 5 }, { GPLEV0, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL6", 0, { GPFSEL0, 18 }, { GPSET0, 6 }, { GPCLR0, 6 }, { GPLEV0, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL7", 0, { GPFSEL0, 21 }, { GPSET0, 7 }, { GPCLR0, 7 }, { GPLEV0, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL8", 0, { GPFSEL0, 24 }, { GPSET0, 8 }, { GPCLR0, 8 }, { GPLEV0, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL9", 0, { GPFSEL0, 27 }, { GPSET0, 9 }, { GPCLR0, 9 }, { GPLEV0, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL10", 0, { GPFSEL1, 0 }, { GPSET0, 10 }, { GPCLR0, 10 }, { GPLEV0, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL11", 0, { GPFSEL1, 3 }, { GPSET0, 11 }, { GPCLR0, 11 }, { GPLEV0, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL12", 0, { GPFSEL1, 6 }, { GPSET0, 12 }, { GPCLR0, 12 }, { GPLEV0, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL13", 0, { GPFSEL1, 9 }, { GPSET0, 13 }, { GPCLR0, 13 }, { GPLEV0, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL14", 0, { GPFSEL1, 12 }, { GPSET0, 14 }, { GPCLR0, 14 }, { GPLEV0, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL15", 0, { GPFSEL1, 15 }, { GPSET0, 15 }, { GPCLR0, 15 }, { GPLEV0, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL16", 0, { GPFSEL1, 18 }, { GPSET0, 16 }, { GPCLR0, 16 }, { GPLEV0, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL17", 0, { GPFSEL1, 21 }, { GPSET0, 17 }, { GPCLR0, 17 }, { GPLEV0, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL18", 0, { GPFSEL1, 24 }, { GPSET0, 18 }, { GPCLR0, 18 }, { GPLEV0, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL19", 0, { GPFSEL1, 27 }, { GPSET0, 19 }, { GPCLR0, 19 }, { GPLEV0, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL20", 0, { GPFSEL2, 0 }, { GPSET0, 20 }, { GPCLR0, 20 }, { GPLEV0, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL21", 0, { GPFSEL2, 3 }, { GPSET0, 21 }, { GPCLR0, 21 }, { GPLEV0, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL22", 0, { GPFSEL2, 6 }, { GPSET0, 22 }, { GPCLR0, 22 }, { GPLEV0, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL23", 0, { GPFSEL2, 9 }, { GPSET0, 23 }, { GPCLR0, 23 }, { GPLEV0, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL24", 0, { GPFSEL2, 12 }, { GPSET0, 24 }, { GPCLR0, 24 }, { GPLEV0, 24 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL25", 0, { GPFSEL2, 15 }, { GPSET0, 25 }, { GPCLR0, 25 }, { GPLEV0, 25 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL26", 0, { GPFSEL2, 18 }, { GPSET0, 26 }, { GPCLR0, 26 }, { GPLEV0, 26 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL27", 0, { GPFSEL2, 21 }, { GPSET0, 27 }, { GPCLR0, 27 }, { GPLEV0, 27 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL28", 0, { GPFSEL2, 24 }, { GPSET0, 28 }, { GPCLR0, 28 }, { GPLEV0, 28 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL29", 0, { GPFSEL2, 27 }, { GPSET0, 29 }, { GPCLR0, 29 }, { GPLEV0, 29 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL30", 0, { GPFSEL3, 0 }, { GPSET0, 30 }, { GPCLR0, 30 }, { GPLEV0, 30 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL31", 0, { GPFSEL3, 3 }, { GPSET0, 31 }, { GPCLR0, 31 }, { GPLEV0, 31 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL32", 0, { GPFSEL3, 6 }, { GPSET1, 0 }, { GPCLR1, 0 }, { GPLEV1, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL33", 0, { GPFSEL3, 9 }, { GPSET1, 1 }, { GPCLR1, 1 }, { GPLEV1, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL34", 0, { GPFSEL3, 12 }, { GPSET1, 2 }, { GPCLR1, 2 }, { GPLEV1, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL35", 0, { GPFSEL3, 15 }, { GPSET1, 3 }, { GPCLR1, 3 }, { GPLEV1, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL36", 0, { GPFSEL3, 18 }, { GPSET1, 4 }, { GPCLR1, 4 }, { GPLEV1, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL37", 0, { GPFSEL3, 21 }, { GPSET1, 5 }, { GPCLR1, 5 }, { GPLEV1, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL38", 0, { GPFSEL3, 24 }, { GPSET1, 6 }, { GPCLR1, 6 }, { GPLEV1, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL39", 0, { GPFSEL3, 27 }, { GPSET1, 7 }, { GPCLR1, 7 }, { GPLEV1, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL40", 0, { GPFSEL4, 0 }, { GPSET1, 8 }, { GPCLR1, 8 }, { GPLEV1, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL41", 0, { GPFSEL4, 3 }, { GPSET1, 9 }, { GPCLR1, 9 }, { GPLEV1, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL42", 0, { GPFSEL4, 6 }, { GPSET1, 10 }, { GPCLR1, 10 }, { GPLEV1, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL43", 0, { GPFSEL4, 9 }, { GPSET1, 11 }, { GPCLR1, 11 }, { GPLEV1, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL44", 0, { GPFSEL4, 12 }, { GPSET1, 12 }, { GPCLR1, 12 }, { GPLEV1, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL45", 0, { GPFSEL4, 15 }, { GPSET1, 13 }, { GPCLR1, 13 }, { GPLEV1, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL46", 0, { GPFSEL4, 18 }, { GPSET1, 14 }, { GPCLR1, 14 }, { GPLEV1, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL47", 0, { GPFSEL4, 21 }, { GPSET1, 15 }, { GPCLR1, 15 }, { GPLEV1, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL48", 0, { GPFSEL4, 24 }, { GPSET1, 16 }, { GPCLR1, 16 }, { GPLEV1, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL49", 0, { GPFSEL4, 27 }, { GPSET1, 17 }, { GPCLR1, 17 }, { GPLEV1, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL50", 0, { GPFSEL5, 0 }, { GPSET1, 18 }, { GPCLR1, 18 }, { GPLEV1, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL51", 0, { GPFSEL5, 3 }, { GPSET1, 19 }, { GPCLR1, 19 }, { GPLEV1, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL52", 0, { GPFSEL5, 6 }, { GPSET1, 20 }, { GPCLR1, 20 }, { GPLEV1, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL53", 0, { GPFSEL5, 9 }, { GPSET1, 21 }, { GPCLR1, 21 }, { GPLEV1, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL0", 0, { GPFSEL0, 0 }, { GPSET0, 0 }, { GPCLR0, 0 }, { GPLEV0, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL1", 0, { GPFSEL0, 3 }, { GPSET0, 1 }, { GPCLR0, 1 }, { GPLEV0, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL2", 0, { GPFSEL0, 6 }, { GPSET0, 2 }, { GPCLR0, 2 }, { GPLEV0, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL3", 0, { GPFSEL0, 9 }, { GPSET0, 3 }, { GPCLR0, 3 }, { GPLEV0, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL4", 0, { GPFSEL0, 12 }, { GPSET0, 4 }, { GPCLR0, 4 }, { GPLEV0, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL5", 0, { GPFSEL0, 15 }, { GPSET0, 5 }, { GPCLR0, 5 }, { GPLEV0, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL6", 0, { GPFSEL0, 18 }, { GPSET0, 6 }, { GPCLR0, 6 }, { GPLEV0, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL7", 0, { GPFSEL0, 21 }, { GPSET0, 7 }, { GPCLR0, 7 }, { GPLEV0, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL8", 0, { GPFSEL0, 24 }, { GPSET0, 8 }, { GPCLR0, 8 }, { GPLEV0, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL9", 0, { GPFSEL0, 27 }, { GPSET0, 9 }, { GPCLR0, 9 }, { GPLEV0, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL10", 0, { GPFSEL1, 0 }, { GPSET0, 10 }, { GPCLR0, 10 }, { GPLEV0, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL11", 0, { GPFSEL1, 3 }, { GPSET0, 11 }, { GPCLR0, 11 }, { GPLEV0, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL12", 0, { GPFSEL1, 6 }, { GPSET0, 12 }, { GPCLR0, 12 }, { GPLEV0, 12 }, { GPIO_ALT0, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL13", 0, { GPFSEL1, 9 }, { GPSET0, 13 }, { GPCLR0, 13 }, { GPLEV0, 13 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL14", 0, { GPFSEL1, 12 }, { GPSET0, 14 }, { GPCLR0, 14 }, { GPLEV0, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL15", 0, { GPFSEL1, 15 }, { GPSET0, 15 }, { GPCLR0, 15 }, { GPLEV0, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL16", 0, { GPFSEL1, 18 }, { GPSET0, 16 }, { GPCLR0, 16 }, { GPLEV0, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL17", 0, { GPFSEL1, 21 }, { GPSET0, 17 }, { GPCLR0, 17 }, { GPLEV0, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL18", 0, { GPFSEL1, 24 }, { GPSET0, 18 }, { GPCLR0, 18 }, { GPLEV0, 18 }, { GPIO_ALT5, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL19", 0, { GPFSEL1, 27 }, { GPSET0, 19 }, { GPCLR0, 19 }, { GPLEV0, 19 }, { GPIO_ALT5, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL20", 0, { GPFSEL2, 0 }, { GPSET0, 20 }, { GPCLR0, 20 }, { GPLEV0, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL21", 0, { GPFSEL2, 3 }, { GPSET0, 21 }, { GPCLR0, 21 }, { GPLEV0, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL22", 0, { GPFSEL2, 6 }, { GPSET0, 22 }, { GPCLR0, 22 }, { GPLEV0, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL23", 0, { GPFSEL2, 9 }, { GPSET0, 23 }, { GPCLR0, 23 }, { GPLEV0, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL24", 0, { GPFSEL2, 12 }, { GPSET0, 24 }, { GPCLR0, 24 }, { GPLEV0, 24 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL25", 0, { GPFSEL2, 15 }, { GPSET0, 25 }, { GPCLR0, 25 }, { GPLEV0, 25 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL26", 0, { GPFSEL2, 18 }, { GPSET0, 26 }, { GPCLR0, 26 }, { GPLEV0, 26 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL27", 0, { GPFSEL2, 21 }, { GPSET0, 27 }, { GPCLR0, 27 }, { GPLEV0, 27 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL28", 0, { GPFSEL2, 24 }, { GPSET0, 28 }, { GPCLR0, 28 }, { GPLEV0, 28 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL29", 0, { GPFSEL2, 27 }, { GPSET0, 29 }, { GPCLR0, 29 }, { GPLEV0, 29 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL30", 0, { GPFSEL3, 0 }, { GPSET0, 30 }, { GPCLR0, 30 }, { GPLEV0, 30 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL31", 0, { GPFSEL3, 3 }, { GPSET0, 31 }, { GPCLR0, 31 }, { GPLEV0, 31 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL32", 0, { GPFSEL3, 6 }, { GPSET1, 0 }, { GPCLR1, 0 }, { GPLEV1, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL33", 0, { GPFSEL3, 9 }, { GPSET1, 1 }, { GPCLR1, 1 }, { GPLEV1, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL34", 0, { GPFSEL3, 12 }, { GPSET1, 2 }, { GPCLR1, 2 }, { GPLEV1, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL35", 0, { GPFSEL3, 15 }, { GPSET1, 3 }, { GPCLR1, 3 }, { GPLEV1, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL36", 0, { GPFSEL3, 18 }, { GPSET1, 4 }, { GPCLR1, 4 }, { GPLEV1, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL37", 0, { GPFSEL3, 21 }, { GPSET1, 5 }, { GPCLR1, 5 }, { GPLEV1, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL38", 0, { GPFSEL3, 24 }, { GPSET1, 6 }, { GPCLR1, 6 }, { GPLEV1, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL39", 0, { GPFSEL3, 27 }, { GPSET1, 7 }, { GPCLR1, 7 }, { GPLEV1, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL40", 0, { GPFSEL4, 0 }, { GPSET1, 8 }, { GPCLR1, 8 }, { GPLEV1, 8 }, { GPIO_ALT0, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL41", 0, { GPFSEL4, 3 }, { GPSET1, 9 }, { GPCLR1, 9 }, { GPLEV1, 9 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL42", 0, { GPFSEL4, 6 }, { GPSET1, 10 }, { GPCLR1, 10 }, { GPLEV1, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL43", 0, { GPFSEL4, 9 }, { GPSET1, 11 }, { GPCLR1, 11 }, { GPLEV1, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL44", 0, { GPFSEL4, 12 }, { GPSET1, 12 }, { GPCLR1, 12 }, { GPLEV1, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL45", 0, { GPFSEL4, 15 }, { GPSET1, 13 }, { GPCLR1, 13 }, { GPLEV1, 13 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL46", 0, { GPFSEL4, 18 }, { GPSET1, 14 }, { GPCLR1, 14 }, { GPLEV1, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL47", 0, { GPFSEL4, 21 }, { GPSET1, 15 }, { GPCLR1, 15 }, { GPLEV1, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL48", 0, { GPFSEL4, 24 }, { GPSET1, 16 }, { GPCLR1, 16 }, { GPLEV1, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL49", 0, { GPFSEL4, 27 }, { GPSET1, 17 }, { GPCLR1, 17 }, { GPLEV1, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL50", 0, { GPFSEL5, 0 }, { GPSET1, 18 }, { GPCLR1, 18 }, { GPLEV1, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL51", 0, { GPFSEL5, 3 }, { GPSET1, 19 }, { GPCLR1, 19 }, { GPLEV1, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL52", 0, { GPFSEL5, 6 }, { GPSET1, 20 }, { GPCLR1, 20 }, { GPLEV1, 20 }, { GPIO_ALT1, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL53", 0, { GPFSEL5, 9 }, { GPSET1, 21 }, { GPCLR1, 21 }, { GPLEV1, 21 }, { GPIO_ALT1, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
 };
+
+static uint32_t pwm_frequency = 100000;
+static uint32_t pwm_range = 1024;
 
 static int broadcom2835Setup(void) {
 	if((broadcom2835->fd = open("/dev/mem", O_RDWR | O_SYNC )) < 0) {
@@ -131,8 +188,16 @@ static int broadcom2835Setup(void) {
 		return -1;
 	}
 
-	if((broadcom2835->gpio[0] = (unsigned char *)mmap(0, broadcom2835->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2835->fd, broadcom2835->base_addr[0])) == NULL) {
+	if((broadcom2835->gpio[0] = (unsigned char *)mmap(0, broadcom2835->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2835->fd, broadcom2835->base_addr[0])) == MAP_FAILED) {
 		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s GPIO memory address", broadcom2835->brand, broadcom2835->chip);
+		return -1;
+	}
+	if((broadcom2835->pwm = (unsigned char *)mmap(0, broadcom2835->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2835->fd, broadcom2835->pwm_addr)) == MAP_FAILED) {
+		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s PWM memory address", broadcom2835->brand, broadcom2835->chip);
+		return -1;
+	}
+	if((broadcom2835->clock = (unsigned char *)mmap(0, broadcom2835->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2835->fd, broadcom2835->clock_addr)) == MAP_FAILED) {
+		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s CLOCK memory address", broadcom2835->brand, broadcom2835->chip);
 		return -1;
 	}
 
@@ -208,33 +273,185 @@ static int broadcom2835DigitalRead(int i) {
 	return (int)((val & (1 << pin->level.bit)) >> pin->level.bit);
 }
 
+
+// The clock frequency should be 19.2MHz (on my raspi it seems to be around
+// 22MHz?), divider maximum is 4096, so a useful range would be 19.2MHz to
+// 4600Hz for the base clock. The clock has also be divided by the pwm range,
+// so the range depends also on the used range.
+//
+// The BCM2835 does not support setting frequency per pin, so pin is unused.
+static int broadcom2835PwmSetClock (int pin, uint32_t frequency)
+{
+	unsigned long pwm_ctl_addr = ((unsigned long)broadcom2835->pwm) + PWM_CTL;
+	unsigned long clk_pwm_ctrl_reg = ((unsigned long)broadcom2835->clock) + CLK_PWM_CTL;
+	unsigned long clk_pwm_div_reg = ((unsigned long)broadcom2835->clock) + CLK_PWM_DIV;
+	uint32_t pwm_control = soc_readl(pwm_ctl_addr);
+
+	pwm_frequency = frequency;
+	uint32_t div = (frequency * pwm_range);
+
+	if (div > PWM_CLOCK_HZ) {
+		div = PWM_CLOCK_HZ;
+	}
+
+	uint32_t divisor = PWM_CLOCK_HZ / div;
+	if (divisor > 4095) {
+		divisor = 4095;
+	}
+	uint32_t div_fract = PWM_CLOCK_HZ % div;
+	div_fract = (uint32_t)((double)div_fract * 4096.0 / (float)PWM_CLOCK_HZ) ;
+
+	// Stop PWM prior to stopping PWM clock
+	soc_writel(pwm_ctl_addr, 0);
+
+	// Stop PWM clock before changing divisor.
+	soc_writel(clk_pwm_ctrl_reg, BCM2836CLK_PASSWORD | 0x01);// Stop PWM Clock
+	delayMicroseconds(110);
+
+	// Wait for clock to be not BUSY
+	while ((soc_readl(clk_pwm_ctrl_reg) & CLK_BUSY) != 0) {
+		delayMicroseconds(1);
+	}
+	soc_writel(clk_pwm_div_reg, BCM2836CLK_PASSWORD | (divisor << 12) | div_fract);
+	soc_writel(clk_pwm_ctrl_reg, BCM2836CLK_PASSWORD | 0x11);// Start PWM clock
+	soc_writel(pwm_ctl_addr, pwm_control);
+	return 0;
+}
+
+static int broadcom2835PwmWrite(int pin, uint32_t val) {
+	struct layout_t *pinlayout = &broadcom2835->layout[broadcom2835->map[pin]];
+	unsigned long addr = 0;
+	unsigned long pwm_rng_addr = (unsigned long)broadcom2835->pwm;
+	uint32_t reg = 0;
+
+	if (pinlayout->mode != PINMODE_PWM_OUTPUT) {
+		wiringXLog(LOG_ERR, "The %s %s GPIO %d is not set to PWM mode",
+							broadcom2835->brand, broadcom2835->chip, pin);
+		return -1;
+	}
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		reg = PWM_DAT1;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		reg = PWM_DAT2;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid definition for pin %d", pin);
+		return -1;
+	}
+	soc_writel (pwm_rng_addr + reg, val);
+
+	return 0;
+}
+
+static int broadcom2835PwmSetRange(int pin, uint32_t range) {
+	struct layout_t *pinlayout = &broadcom2835->layout[broadcom2835->map[pin]];
+	unsigned long pwm_rng_addr = (unsigned long)broadcom2835->pwm;
+	uint32_t reg = 0;
+
+	if (range < 1) {
+		wiringXLog(LOG_ERR, "Range must be at least 1");
+		return -1;
+	}
+	if (pinlayout->mode != PINMODE_PWM_OUTPUT) {
+		wiringXLog(LOG_ERR, "The %s %s GPIO %d is not set to PWM mode",
+							broadcom2835->brand, broadcom2835->chip, pin);
+		return -1;
+	}
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		reg = PWM_RNG1;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		reg = PWM_RNG2;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid definition for pin %d", pin);
+		return -1;
+	}
+
+	pwm_range = range;
+	broadcom2835PwmSetClock (pin, pwm_frequency);
+	soc_writel (pwm_rng_addr + reg, range);
+
+	return 0;
+}
+
+// Enable a PWM channel
+static int broadcom2835PwmEnableChannel(enum pwm_channel_t channel) {
+	uint32_t val = 0;
+	uint32_t enable = 0;
+	unsigned long pwm_ctl_addr = ((unsigned long) broadcom2835->pwm) + PWM_CTL;
+	if (channel == PWM_CHANNEL0) {
+		enable = PWM0_ENABLE | PWM0_MSEN;
+	} else if (channel == PWM_CHANNEL1) {
+		enable = PWM1_ENABLE | PWM1_MSEN;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel %d", channel);
+		return -1;
+	}
+	val = soc_readl(pwm_ctl_addr);
+	val |= enable;
+	soc_writel(pwm_ctl_addr, val);
+	return 0;
+}
+
+static void broadcom2835FunctionSelect(unsigned long addr, struct layout_t *pin,
+									   enum functionselect_t fsel) {
+	uint32_t val = soc_readl(addr);
+	uint32_t mask = 0b111;
+	uint32_t sel = fsel;
+	mask = mask << pin->select.bit;
+	sel = sel << pin->select.bit;
+	val &= ~mask;
+	val |= sel;
+	soc_writel(addr, val);
+}
+
 static int broadcom2835PinMode(int i, enum pinmode_t mode) {
 	struct layout_t *pin = NULL;
 	unsigned long addr = 0;
-	uint32_t val = 0;
 
-	if(broadcom2835->map == NULL) {
-		wiringXLog(LOG_ERR, "The %s %s has not yet been mapped", broadcom2835->brand, broadcom2835->chip);
-		return -1; 
-	} 
-	if(broadcom2835->fd <= 0 || broadcom2835->gpio == NULL) {
-		wiringXLog(LOG_ERR, "The %s %s has not yet been setup by wiringX", broadcom2835->brand, broadcom2835->chip);
+	if (broadcom2835->map == NULL) {
+		wiringXLog(LOG_ERR, "The %s %s has not yet been mapped",
+				broadcom2835->brand, broadcom2835->chip);
+		return -1;
+	}
+	if (broadcom2835->fd <= 0 || broadcom2835->gpio == NULL) {
+		wiringXLog(LOG_ERR, "The %s %s has not yet been setup by wiringX",
+				broadcom2835->brand, broadcom2835->chip);
 		return -1;
 	}
 
 	pin = &broadcom2835->layout[broadcom2835->map[i]];
-	addr = (unsigned long)(broadcom2835->gpio[pin->addr] + broadcom2835->base_offs[pin->addr] + pin->select.offset);
-	pin->mode = mode;
+	addr = (unsigned long) (broadcom2835->gpio[pin->addr]
+			+ broadcom2835->base_offs[pin->addr] + pin->select.offset);
 
-	val = soc_readl(addr);
-	if(mode == PINMODE_OUTPUT) {
-		val |= (1 << pin->select.bit);
-	} else if(mode == PINMODE_INPUT) {
-		val &= ~(1 << pin->select.bit);
+	switch (mode) {
+	case PINMODE_OUTPUT:
+		broadcom2835FunctionSelect(addr, pin, GPIO_OUTPUT);
+		pin->mode = PINMODE_OUTPUT;
+		break;
+	case PINMODE_INPUT:
+		broadcom2835FunctionSelect(addr, pin, GPIO_INPUT);
+		pin->mode = PINMODE_INPUT;
+		break;
+	case PINMODE_PWM_OUTPUT:
+		if (pin->pwm.alt_mode != GPIO_UNDEF) {
+			pin->mode = PINMODE_PWM_OUTPUT;
+			broadcom2835FunctionSelect(addr, pin, pin->pwm.alt_mode);
+			delayMicroseconds(110);
+			broadcom2835PwmEnableChannel(pin->pwm.pwm_channel);
+			broadcom2835PwmSetClock(0, 100000);
+			broadcom2835PwmSetRange(i, 1024);	// Default range of 1024
+			broadcom2835PwmWrite(i, 0);
+		} else {
+			wiringXLog(LOG_ERR, "Pin %d (%s) does not support PWM\n", i,
+					pin->name);
+			pin->mode = PINMODE_NOT_SET;
+		}
+
+		break;
+	default:
+		wiringXLog(LOG_ERR, "Unsupported pin mode %d\n", mode);
+		pin->mode = PINMODE_NOT_SET;
+		return -1;
 	}
-	val &= ~(1 << (pin->select.bit+1));
-	val &= ~(1 << (pin->select.bit+2));
-	soc_writel(addr, val);
 
 	return 0;
 }
@@ -323,7 +540,13 @@ static int broadcom2835GC(void) {
 	}
 	if(broadcom2835->gpio[0] != NULL) {
 		munmap(broadcom2835->gpio[0], broadcom2835->page_size);
-	} 
+	}
+	if(broadcom2835->pwm != NULL) {
+		munmap(broadcom2835->pwm, broadcom2835->page_size);
+	}
+	if(broadcom2835->clock != NULL) {
+		munmap(broadcom2835->clock, broadcom2835->page_size);
+	}
 	return 0;
 }
 
@@ -353,6 +576,8 @@ void broadcom2835Init(void) {
 	broadcom2835->page_size = (4*1024);
 	broadcom2835->base_addr[0] = 0x20200000;
 	broadcom2835->base_offs[0] = 0x00000000;
+	broadcom2835->pwm_addr     = 0x2020C000;
+	broadcom2835->clock_addr   = 0x20101000;
 
 	broadcom2835->gc = &broadcom2835GC;
 	broadcom2835->selectableFd = &broadcom2835SelectableFd;
@@ -366,4 +591,7 @@ void broadcom2835Init(void) {
 	broadcom2835->setIRQ = &broadcom2835SetIRQ;
 	broadcom2835->isr = &broadcom2835ISR;
 	broadcom2835->waitForInterrupt = &broadcom2835WaitForInterrupt;
+	broadcom2835->pwmSetClock = &broadcom2835PwmSetClock;
+	broadcom2835->pwmSetRange = &broadcom2835PwmSetRange;
+	broadcom2835->pwmWrite = &broadcom2835PwmWrite;
 }

--- a/src/soc/broadcom/2836.c
+++ b/src/soc/broadcom/2836.c
@@ -37,6 +37,56 @@ struct soc_t *broadcom2836 = NULL;
 #define GPLEV0	0x34
 #define GPLEV1	0x38
 
+enum functionselect_t {
+	GPIO_INPUT  = 0b000,
+	GPIO_OUTPUT = 0b001,
+	GPIO_ALT0 = 0b100,
+	GPIO_ALT1 = 0b101,
+	GPIO_ALT2 = 0b110,
+	GPIO_ALT3 = 0b111,
+	GPIO_ALT4 = 0b011,
+	GPIO_ALT5 = 0b010,
+	GPIO_UNDEF      = -1
+};
+
+enum pwm_channel_t {
+	PWM_CHANNEL0,
+	PWM_CHANNEL1,
+	PWM_NOCHANNEL
+};
+
+#define PWM_CLOCK_HZ 19200000
+// PWM Registers
+#define PWM_CTL		0x00
+#define PWM_STA		0x04
+#define PWM_DMAC	0x08
+#define PWM_RNG1	0x10
+#define PWM_DAT1	0x14
+#define PWM_FIF1	0x18
+#define PWM_RNG2	0x20
+#define PWM_DAT2	0x24
+
+#define PWM0_ENABLE		1 << 0  // Channel Enable
+#define PWM0_MSEN		1 << 7
+#define PWM1_ENABLE		1 << 8 // Channel Enable
+#define PWM1_MSEN		1 << 15
+
+#define BCM2836CLK_PASSWORD 0x5A000000
+#define CLK_GP0_CTL 0x70
+#define CLK_GP0_DIV 0x74
+#define CLK_GP1_CTL 0x78
+#define CLK_GP1_DIV 0x7C
+#define CLK_GP2_CTL 0x80
+#define CLK_GP2_DIV 0x84
+
+#define CLK_PCM_CTL 0x98
+#define CLK_PCM_DIV 0x9C
+
+#define CLK_PWM_CTL 0xA0
+#define CLK_PWM_DIV 0xA4
+
+#define CLK_BUSY 0x80
+
 static struct layout_t {
 	char *name;
 
@@ -62,6 +112,10 @@ static struct layout_t {
 		unsigned long bit;
 	} level;	
 
+    struct {
+		enum functionselect_t alt_mode;
+		enum pwm_channel_t pwm_channel;
+	} pwm;
 	int support;
 
 	enum pinmode_t mode;
@@ -69,61 +123,64 @@ static struct layout_t {
 	int fd;
 
 } layout[] = {
-	{ "FSEL0", 0, { GPFSEL0, 0 }, { GPSET0, 0 }, { GPCLR0, 0 }, { GPLEV0, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL1", 0, { GPFSEL0, 3 }, { GPSET0, 1 }, { GPCLR0, 1 }, { GPLEV0, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL2", 0, { GPFSEL0, 6 }, { GPSET0, 2 }, { GPCLR0, 2 }, { GPLEV0, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL3", 0, { GPFSEL0, 9 }, { GPSET0, 3 }, { GPCLR0, 3 }, { GPLEV0, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL4", 0, { GPFSEL0, 12 }, { GPSET0, 4 }, { GPCLR0, 4 }, { GPLEV0, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL5", 0, { GPFSEL0, 15 }, { GPSET0, 5 }, { GPCLR0, 5 }, { GPLEV0, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL6", 0, { GPFSEL0, 18 }, { GPSET0, 6 }, { GPCLR0, 6 }, { GPLEV0, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL7", 0, { GPFSEL0, 21 }, { GPSET0, 7 }, { GPCLR0, 7 }, { GPLEV0, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL8", 0, { GPFSEL0, 24 }, { GPSET0, 8 }, { GPCLR0, 8 }, { GPLEV0, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL9", 0, { GPFSEL0, 27 }, { GPSET0, 9 }, { GPCLR0, 9 }, { GPLEV0, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL10", 0, { GPFSEL1, 0 }, { GPSET0, 10 }, { GPCLR0, 10 }, { GPLEV0, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL11", 0, { GPFSEL1, 3 }, { GPSET0, 11 }, { GPCLR0, 11 }, { GPLEV0, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL12", 0, { GPFSEL1, 6 }, { GPSET0, 12 }, { GPCLR0, 12 }, { GPLEV0, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL13", 0, { GPFSEL1, 9 }, { GPSET0, 13 }, { GPCLR0, 13 }, { GPLEV0, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL14", 0, { GPFSEL1, 12 }, { GPSET0, 14 }, { GPCLR0, 14 }, { GPLEV0, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL15", 0, { GPFSEL1, 15 }, { GPSET0, 15 }, { GPCLR0, 15 }, { GPLEV0, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL16", 0, { GPFSEL1, 18 }, { GPSET0, 16 }, { GPCLR0, 16 }, { GPLEV0, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL17", 0, { GPFSEL1, 21 }, { GPSET0, 17 }, { GPCLR0, 17 }, { GPLEV0, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL18", 0, { GPFSEL1, 24 }, { GPSET0, 18 }, { GPCLR0, 18 }, { GPLEV0, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL19", 0, { GPFSEL1, 27 }, { GPSET0, 19 }, { GPCLR0, 19 }, { GPLEV0, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL20", 0, { GPFSEL2, 0 }, { GPSET0, 20 }, { GPCLR0, 20 }, { GPLEV0, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL21", 0, { GPFSEL2, 3 }, { GPSET0, 21 }, { GPCLR0, 21 }, { GPLEV0, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL22", 0, { GPFSEL2, 6 }, { GPSET0, 22 }, { GPCLR0, 22 }, { GPLEV0, 22 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL23", 0, { GPFSEL2, 9 }, { GPSET0, 23 }, { GPCLR0, 23 }, { GPLEV0, 23 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL24", 0, { GPFSEL2, 12 }, { GPSET0, 24 }, { GPCLR0, 24 }, { GPLEV0, 24 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL25", 0, { GPFSEL2, 15 }, { GPSET0, 25 }, { GPCLR0, 25 }, { GPLEV0, 25 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL26", 0, { GPFSEL2, 18 }, { GPSET0, 26 }, { GPCLR0, 26 }, { GPLEV0, 26 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL27", 0, { GPFSEL2, 21 }, { GPSET0, 27 }, { GPCLR0, 27 }, { GPLEV0, 27 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL28", 0, { GPFSEL2, 24 }, { GPSET0, 28 }, { GPCLR0, 28 }, { GPLEV0, 28 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL29", 0, { GPFSEL2, 27 }, { GPSET0, 29 }, { GPCLR0, 29 }, { GPLEV0, 29 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL30", 0, { GPFSEL3, 0 }, { GPSET0, 30 }, { GPCLR0, 30 }, { GPLEV0, 30 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL31", 0, { GPFSEL3, 3 }, { GPSET0, 31 }, { GPCLR0, 31 }, { GPLEV0, 31 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL32", 0, { GPFSEL3, 6 }, { GPSET1, 0 }, { GPCLR1, 0 }, { GPLEV1, 0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL33", 0, { GPFSEL3, 9 }, { GPSET1, 1 }, { GPCLR1, 1 }, { GPLEV1, 1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL34", 0, { GPFSEL3, 12 }, { GPSET1, 2 }, { GPCLR1, 2 }, { GPLEV1, 2 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL35", 0, { GPFSEL3, 15 }, { GPSET1, 3 }, { GPCLR1, 3 }, { GPLEV1, 3 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL36", 0, { GPFSEL3, 18 }, { GPSET1, 4 }, { GPCLR1, 4 }, { GPLEV1, 4 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL37", 0, { GPFSEL3, 21 }, { GPSET1, 5 }, { GPCLR1, 5 }, { GPLEV1, 5 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL38", 0, { GPFSEL3, 24 }, { GPSET1, 6 }, { GPCLR1, 6 }, { GPLEV1, 6 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL39", 0, { GPFSEL3, 27 }, { GPSET1, 7 }, { GPCLR1, 7 }, { GPLEV1, 7 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL40", 0, { GPFSEL4, 0 }, { GPSET1, 8 }, { GPCLR1, 8 }, { GPLEV1, 8 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL41", 0, { GPFSEL4, 3 }, { GPSET1, 9 }, { GPCLR1, 9 }, { GPLEV1, 9 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL42", 0, { GPFSEL4, 6 }, { GPSET1, 10 }, { GPCLR1, 10 }, { GPLEV1, 10 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL43", 0, { GPFSEL4, 9 }, { GPSET1, 11 }, { GPCLR1, 11 }, { GPLEV1, 11 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL44", 0, { GPFSEL4, 12 }, { GPSET1, 12 }, { GPCLR1, 12 }, { GPLEV1, 12 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL45", 0, { GPFSEL4, 15 }, { GPSET1, 13 }, { GPCLR1, 13 }, { GPLEV1, 13 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL46", 0, { GPFSEL4, 18 }, { GPSET1, 14 }, { GPCLR1, 14 }, { GPLEV1, 14 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL47", 0, { GPFSEL4, 21 }, { GPSET1, 15 }, { GPCLR1, 15 }, { GPLEV1, 15 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL48", 0, { GPFSEL4, 24 }, { GPSET1, 16 }, { GPCLR1, 16 }, { GPLEV1, 16 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL49", 0, { GPFSEL4, 27 }, { GPSET1, 17 }, { GPCLR1, 17 }, { GPLEV1, 17 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL50", 0, { GPFSEL5, 0 }, { GPSET1, 18 }, { GPCLR1, 18 }, { GPLEV1, 18 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL51", 0, { GPFSEL5, 3 }, { GPSET1, 19 }, { GPCLR1, 19 }, { GPLEV1, 19 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL52", 0, { GPFSEL5, 6 }, { GPSET1, 20 }, { GPCLR1, 20 }, { GPLEV1, 20 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
-	{ "FSEL53", 0, { GPFSEL5, 9 }, { GPSET1, 21 }, { GPCLR1, 21 }, { GPLEV1, 21 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL0", 0, { GPFSEL0, 0 }, { GPSET0, 0 }, { GPCLR0, 0 }, { GPLEV0, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL1", 0, { GPFSEL0, 3 }, { GPSET0, 1 }, { GPCLR0, 1 }, { GPLEV0, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL2", 0, { GPFSEL0, 6 }, { GPSET0, 2 }, { GPCLR0, 2 }, { GPLEV0, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL3", 0, { GPFSEL0, 9 }, { GPSET0, 3 }, { GPCLR0, 3 }, { GPLEV0, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL4", 0, { GPFSEL0, 12 }, { GPSET0, 4 }, { GPCLR0, 4 }, { GPLEV0, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL5", 0, { GPFSEL0, 15 }, { GPSET0, 5 }, { GPCLR0, 5 }, { GPLEV0, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL6", 0, { GPFSEL0, 18 }, { GPSET0, 6 }, { GPCLR0, 6 }, { GPLEV0, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL7", 0, { GPFSEL0, 21 }, { GPSET0, 7 }, { GPCLR0, 7 }, { GPLEV0, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL8", 0, { GPFSEL0, 24 }, { GPSET0, 8 }, { GPCLR0, 8 }, { GPLEV0, 8 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL9", 0, { GPFSEL0, 27 }, { GPSET0, 9 }, { GPCLR0, 9 }, { GPLEV0, 9 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL10", 0, { GPFSEL1, 0 }, { GPSET0, 10 }, { GPCLR0, 10 }, { GPLEV0, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL11", 0, { GPFSEL1, 3 }, { GPSET0, 11 }, { GPCLR0, 11 }, { GPLEV0, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL12", 0, { GPFSEL1, 6 }, { GPSET0, 12 }, { GPCLR0, 12 }, { GPLEV0, 12 }, { GPIO_ALT0, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL13", 0, { GPFSEL1, 9 }, { GPSET0, 13 }, { GPCLR0, 13 }, { GPLEV0, 13 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL14", 0, { GPFSEL1, 12 }, { GPSET0, 14 }, { GPCLR0, 14 }, { GPLEV0, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL15", 0, { GPFSEL1, 15 }, { GPSET0, 15 }, { GPCLR0, 15 }, { GPLEV0, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL16", 0, { GPFSEL1, 18 }, { GPSET0, 16 }, { GPCLR0, 16 }, { GPLEV0, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL17", 0, { GPFSEL1, 21 }, { GPSET0, 17 }, { GPCLR0, 17 }, { GPLEV0, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL18", 0, { GPFSEL1, 24 }, { GPSET0, 18 }, { GPCLR0, 18 }, { GPLEV0, 18 }, { GPIO_ALT5, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL19", 0, { GPFSEL1, 27 }, { GPSET0, 19 }, { GPCLR0, 19 }, { GPLEV0, 19 }, { GPIO_ALT5, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL20", 0, { GPFSEL2, 0 }, { GPSET0, 20 }, { GPCLR0, 20 }, { GPLEV0, 20 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL21", 0, { GPFSEL2, 3 }, { GPSET0, 21 }, { GPCLR0, 21 }, { GPLEV0, 21 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL22", 0, { GPFSEL2, 6 }, { GPSET0, 22 }, { GPCLR0, 22 }, { GPLEV0, 22 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL23", 0, { GPFSEL2, 9 }, { GPSET0, 23 }, { GPCLR0, 23 }, { GPLEV0, 23 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL24", 0, { GPFSEL2, 12 }, { GPSET0, 24 }, { GPCLR0, 24 }, { GPLEV0, 24 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL25", 0, { GPFSEL2, 15 }, { GPSET0, 25 }, { GPCLR0, 25 }, { GPLEV0, 25 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL26", 0, { GPFSEL2, 18 }, { GPSET0, 26 }, { GPCLR0, 26 }, { GPLEV0, 26 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL27", 0, { GPFSEL2, 21 }, { GPSET0, 27 }, { GPCLR0, 27 }, { GPLEV0, 27 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL28", 0, { GPFSEL2, 24 }, { GPSET0, 28 }, { GPCLR0, 28 }, { GPLEV0, 28 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL29", 0, { GPFSEL2, 27 }, { GPSET0, 29 }, { GPCLR0, 29 }, { GPLEV0, 29 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL30", 0, { GPFSEL3, 0 }, { GPSET0, 30 }, { GPCLR0, 30 }, { GPLEV0, 30 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL31", 0, { GPFSEL3, 3 }, { GPSET0, 31 }, { GPCLR0, 31 }, { GPLEV0, 31 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL32", 0, { GPFSEL3, 6 }, { GPSET1, 0 }, { GPCLR1, 0 }, { GPLEV1, 0 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL33", 0, { GPFSEL3, 9 }, { GPSET1, 1 }, { GPCLR1, 1 }, { GPLEV1, 1 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL34", 0, { GPFSEL3, 12 }, { GPSET1, 2 }, { GPCLR1, 2 }, { GPLEV1, 2 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL35", 0, { GPFSEL3, 15 }, { GPSET1, 3 }, { GPCLR1, 3 }, { GPLEV1, 3 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL36", 0, { GPFSEL3, 18 }, { GPSET1, 4 }, { GPCLR1, 4 }, { GPLEV1, 4 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL37", 0, { GPFSEL3, 21 }, { GPSET1, 5 }, { GPCLR1, 5 }, { GPLEV1, 5 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL38", 0, { GPFSEL3, 24 }, { GPSET1, 6 }, { GPCLR1, 6 }, { GPLEV1, 6 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL39", 0, { GPFSEL3, 27 }, { GPSET1, 7 }, { GPCLR1, 7 }, { GPLEV1, 7 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL40", 0, { GPFSEL4, 0 }, { GPSET1, 8 }, { GPCLR1, 8 }, { GPLEV1, 8 }, { GPIO_ALT0, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL41", 0, { GPFSEL4, 3 }, { GPSET1, 9 }, { GPCLR1, 9 }, { GPLEV1, 9 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL42", 0, { GPFSEL4, 6 }, { GPSET1, 10 }, { GPCLR1, 10 }, { GPLEV1, 10 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL43", 0, { GPFSEL4, 9 }, { GPSET1, 11 }, { GPCLR1, 11 }, { GPLEV1, 11 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL44", 0, { GPFSEL4, 12 }, { GPSET1, 12 }, { GPCLR1, 12 }, { GPLEV1, 12 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL45", 0, { GPFSEL4, 15 }, { GPSET1, 13 }, { GPCLR1, 13 }, { GPLEV1, 13 }, { GPIO_ALT0, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL46", 0, { GPFSEL4, 18 }, { GPSET1, 14 }, { GPCLR1, 14 }, { GPLEV1, 14 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL47", 0, { GPFSEL4, 21 }, { GPSET1, 15 }, { GPCLR1, 15 }, { GPLEV1, 15 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL48", 0, { GPFSEL4, 24 }, { GPSET1, 16 }, { GPCLR1, 16 }, { GPLEV1, 16 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL49", 0, { GPFSEL4, 27 }, { GPSET1, 17 }, { GPCLR1, 17 }, { GPLEV1, 17 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL50", 0, { GPFSEL5, 0 }, { GPSET1, 18 }, { GPCLR1, 18 }, { GPLEV1, 18 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL51", 0, { GPFSEL5, 3 }, { GPSET1, 19 }, { GPCLR1, 19 }, { GPLEV1, 19 }, { GPIO_UNDEF, PWM_NOCHANNEL }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL52", 0, { GPFSEL5, 6 }, { GPSET1, 20 }, { GPCLR1, 20 }, { GPLEV1, 20 }, { GPIO_ALT1, PWM_CHANNEL0 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
+	{ "FSEL53", 0, { GPFSEL5, 9 }, { GPSET1, 21 }, { GPCLR1, 21 }, { GPLEV1, 21 }, { GPIO_ALT1, PWM_CHANNEL1 }, FUNCTION_DIGITAL, PINMODE_NOT_SET, 0 },
 };
+
+static uint32_t pwm_frequency = 100000;
+static uint32_t pwm_range = 1024;
 
 static int broadcom2836Setup(void) {
 	if((broadcom2836->fd = open("/dev/mem", O_RDWR | O_SYNC )) < 0) {
@@ -135,7 +192,14 @@ static int broadcom2836Setup(void) {
 		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s GPIO memory address", broadcom2836->brand, broadcom2836->chip);
 		return -1;
 	}
-
+	if((broadcom2836->pwm = (unsigned char *)mmap(0, broadcom2836->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2836->fd, broadcom2836->pwm_addr)) == MAP_FAILED) {
+		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s PWM memory address", broadcom2836->brand, broadcom2836->chip);
+		return -1;
+	}
+	if((broadcom2836->clock = (unsigned char *)mmap(0, broadcom2836->page_size, PROT_READ|PROT_WRITE, MAP_SHARED, broadcom2836->fd, broadcom2836->clock_addr)) == MAP_FAILED) {
+		wiringXLog(LOG_ERR, "wiringX failed to map the %s %s CLOCK memory address", broadcom2836->brand, broadcom2836->chip);
+		return -1;
+	}
 	return 0;
 }
 
@@ -208,33 +272,188 @@ static int broadcom2836DigitalRead(int i) {
 	return (int)((val & (1 << pin->level.bit)) >> pin->level.bit);
 }
 
+// The clock frequency should be 19.2MHz (on my raspi it seems to be around
+// 22MHz?), divider maximum is 4096, minimum is 2, so a useful range would be
+// 19.2MHz to 10000Hz for the base clock. The clock has also be divided by the
+// pwm range, so the range depends also on the used range.
+//
+// The BCM2836 does not support setting frequency per pin, so pin is unused.
+// Also thte BCM2836 seems not to honor the fraction part of the counter.
+static int broadcom2836PwmSetClock (int pin, uint32_t frequency)
+{
+	unsigned long pwm_ctl_addr = ((unsigned long)broadcom2836->pwm) + PWM_CTL;
+	unsigned long clk_pwm_ctrl_reg = ((unsigned long)broadcom2836->clock) + CLK_PWM_CTL;
+	unsigned long clk_pwm_div_reg = ((unsigned long)broadcom2836->clock) + CLK_PWM_DIV;
+	uint32_t pwm_control = soc_readl(pwm_ctl_addr);
+
+	pwm_frequency = frequency;
+	uint32_t div = (frequency * pwm_range);
+
+	if (div > PWM_CLOCK_HZ) {
+		div = PWM_CLOCK_HZ;
+	}
+
+	uint32_t divisor = PWM_CLOCK_HZ / div;
+	if (divisor > 4095) {
+		divisor = 4095;
+	}
+	// The BCM2836 does not like 1 as divisor. Clock is getting very slow then.
+	if (divisor < 2) {
+		divisor = 2;
+	}
+
+	// Stop PWM prior to stopping PWM clock
+	soc_writel(pwm_ctl_addr, 0);
+
+	// Stop PWM clock before changing divisor.
+	soc_writel(clk_pwm_ctrl_reg, BCM2836CLK_PASSWORD | 0x01);// Stop PWM Clock
+	delayMicroseconds(110);
+
+	// Wait for clock to be not BUSY
+	while ((soc_readl(clk_pwm_ctrl_reg) & CLK_BUSY) != 0) {
+		delayMicroseconds(1);
+	}
+	soc_writel(clk_pwm_div_reg, BCM2836CLK_PASSWORD | (divisor << 12));
+	soc_writel(clk_pwm_ctrl_reg, BCM2836CLK_PASSWORD | 0x11);// Start PWM clock
+	soc_writel(pwm_ctl_addr, pwm_control);
+	return 0;
+}
+
+static int broadcom2836PwmWrite(int pin, uint32_t val) {
+	struct layout_t *pinlayout = &broadcom2836->layout[broadcom2836->map[pin]];
+	unsigned long addr = 0;
+	unsigned long pwm_rng_addr = (unsigned long)broadcom2836->pwm;
+	uint32_t reg = 0;
+
+	if (pinlayout->mode != PINMODE_PWM_OUTPUT) {
+		wiringXLog(LOG_ERR, "The %s %s GPIO %d is not set to PWM mode",
+							broadcom2836->brand, broadcom2836->chip, pin);
+		return -1;
+	}
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		reg = PWM_DAT1;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		reg = PWM_DAT2;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid definition for pin %d", pin);
+		return -1;
+	}
+	soc_writel (pwm_rng_addr + reg, val);
+
+	return 0;
+}
+
+static int broadcom2836PwmSetRange(int pin, uint32_t range) {
+	struct layout_t *pinlayout = &broadcom2836->layout[broadcom2836->map[pin]];
+	unsigned long pwm_rng_addr = (unsigned long)broadcom2836->pwm;
+	uint32_t reg = 0;
+
+	if (range < 1) {
+		wiringXLog(LOG_ERR, "Range must be at least 1");
+		return -1;
+	}
+	if (pinlayout->mode != PINMODE_PWM_OUTPUT) {
+		wiringXLog(LOG_ERR, "The %s %s GPIO %d is not set to PWM mode",
+							broadcom2836->brand, broadcom2836->chip, pin);
+		return -1;
+	}
+	if (pinlayout->pwm.pwm_channel == PWM_CHANNEL0) {
+		reg = PWM_RNG1;
+	} else if (pinlayout->pwm.pwm_channel == PWM_CHANNEL1) {
+		reg = PWM_RNG2;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid definition for pin %d", pin);
+		return -1;
+	}
+
+	pwm_range = range;
+	soc_writel (pwm_rng_addr + reg, range);
+
+	broadcom2836PwmSetClock (pin, pwm_frequency);
+
+	return 0;
+}
+
+// Enable a PWM channel
+static int broadcom2836PwmEnableChannel(enum pwm_channel_t channel) {
+	uint32_t val = 0;
+	uint32_t enable = 0;
+	unsigned long pwm_ctl_addr = ((unsigned long) broadcom2836->pwm) + PWM_CTL;
+	if (channel == PWM_CHANNEL0) {
+		enable = PWM0_ENABLE | PWM0_MSEN;
+	} else if (channel == PWM_CHANNEL1) {
+		enable = PWM1_ENABLE | PWM1_MSEN;
+	} else {
+		wiringXLog(LOG_ERR, "Invalid channel %d", channel);
+		return -1;
+	}
+	val = soc_readl(pwm_ctl_addr);
+	val |= enable;
+	soc_writel(pwm_ctl_addr, val);
+	return 0;
+}
+
+static void broadcom2836FunctionSelect(unsigned long addr, struct layout_t *pin,
+									   enum functionselect_t fsel) {
+	uint32_t val = soc_readl(addr);
+	uint32_t mask = 0b111;
+	uint32_t sel = fsel;
+	mask = mask << pin->select.bit;
+	sel = sel << pin->select.bit;
+	val &= ~mask;
+	val |= sel;
+	soc_writel(addr, val);
+}
+
 static int broadcom2836PinMode(int i, enum pinmode_t mode) {
 	struct layout_t *pin = NULL;
 	unsigned long addr = 0;
-	uint32_t val = 0;
 
-	if(broadcom2836->map == NULL) {
-		wiringXLog(LOG_ERR, "The %s %s has not yet been mapped", broadcom2836->brand, broadcom2836->chip);
-		return -1; 
-	} 
-	if(broadcom2836->fd <= 0 || broadcom2836->gpio == NULL) {
-		wiringXLog(LOG_ERR, "The %s %s has not yet been setup by wiringX", broadcom2836->brand, broadcom2836->chip);
+	if (broadcom2836->map == NULL) {
+		wiringXLog(LOG_ERR, "The %s %s has not yet been mapped",
+				broadcom2836->brand, broadcom2836->chip);
+		return -1;
+	}
+	if (broadcom2836->fd <= 0 || broadcom2836->gpio == NULL) {
+		wiringXLog(LOG_ERR, "The %s %s has not yet been setup by wiringX",
+				broadcom2836->brand, broadcom2836->chip);
 		return -1;
 	}
 
 	pin = &broadcom2836->layout[broadcom2836->map[i]];
-	addr = (unsigned long)(broadcom2836->gpio[pin->addr] + broadcom2836->base_offs[pin->addr] + pin->select.offset);
-	pin->mode = mode;
+	addr = (unsigned long) (broadcom2836->gpio[pin->addr]
+			+ broadcom2836->base_offs[pin->addr] + pin->select.offset);
 
-	val = soc_readl(addr);
-	if(mode == PINMODE_OUTPUT) {
-		val |= (1 << pin->select.bit);
-	} else if(mode == PINMODE_INPUT) {
-		val &= ~(1 << pin->select.bit);
+	switch (mode) {
+	case PINMODE_OUTPUT:
+		broadcom2836FunctionSelect(addr, pin, GPIO_OUTPUT);
+		pin->mode = PINMODE_OUTPUT;
+		break;
+	case PINMODE_INPUT:
+		broadcom2836FunctionSelect(addr, pin, GPIO_INPUT);
+		pin->mode = PINMODE_INPUT;
+		break;
+	case PINMODE_PWM_OUTPUT:
+		if (pin->pwm.alt_mode != GPIO_UNDEF) {
+			pin->mode = PINMODE_PWM_OUTPUT;
+			broadcom2836FunctionSelect(addr, pin, pin->pwm.alt_mode);
+			delayMicroseconds(110);
+			broadcom2836PwmEnableChannel(pin->pwm.pwm_channel);
+			broadcom2836PwmSetClock(0, 100000);
+			broadcom2836PwmSetRange(i, 1024);	// Default range of 1024
+			broadcom2836PwmWrite(i, 0);
+		} else {
+			wiringXLog(LOG_ERR, "Pin %d (%s) does not support PWM\n", i,
+					pin->name);
+			pin->mode = PINMODE_NOT_SET;
+		}
+
+		break;
+	default:
+		wiringXLog(LOG_ERR, "Unsupported pin mode %d\n", mode);
+		pin->mode = PINMODE_NOT_SET;
+		return -1;
 	}
-	val &= ~(1 << (pin->select.bit+1));
-	val &= ~(1 << (pin->select.bit+2));
-	soc_writel(addr, val);
 
 	return 0;
 }
@@ -323,7 +542,13 @@ static int broadcom2836GC(void) {
 	}
 	if(broadcom2836->gpio[0] != NULL) {
 		munmap(broadcom2836->gpio[0], broadcom2836->page_size);
-	} 
+	}
+	if(broadcom2836->pwm != NULL) {
+		munmap(broadcom2836->pwm, broadcom2836->page_size);
+	}
+	if(broadcom2836->clock != NULL) {
+		munmap(broadcom2836->clock, broadcom2836->page_size);
+	}
 	return 0;
 }
 
@@ -357,6 +582,8 @@ void broadcom2836Init(void) {
 	broadcom2836->page_size = (4*1024);
 	broadcom2836->base_addr[0] = 0x3F200000;
 	broadcom2836->base_offs[0] = 0x00000000;
+	broadcom2836->pwm_addr     = 0x3F20C000;
+	broadcom2836->clock_addr   = 0x3F101000;
 
 	broadcom2836->gc = &broadcom2836GC;
 	broadcom2836->selectableFd = &broadcom2836SelectableFd;
@@ -370,4 +597,7 @@ void broadcom2836Init(void) {
 	broadcom2836->setIRQ = &broadcom2836SetIRQ;
 	broadcom2836->isr = &broadcom2836ISR;
 	broadcom2836->waitForInterrupt = &broadcom2836WaitForInterrupt;
+	broadcom2836->pwmSetClock = &broadcom2836PwmSetClock;
+	broadcom2836->pwmSetRange = &broadcom2836PwmSetRange;
+	broadcom2836->pwmWrite = &broadcom2836PwmWrite;
 }

--- a/src/soc/soc.c
+++ b/src/soc/soc.c
@@ -48,6 +48,9 @@ void soc_register(struct soc_t **soc, char *brand, char *type) {
 	(*soc)->setup = NULL;
 	(*soc)->digitalRead = NULL;
 	(*soc)->digitalWrite = NULL;
+	(*soc)->pwmSetClock = NULL;
+	(*soc)->pwmSetRange = NULL;
+	(*soc)->pwmWrite = NULL;
 	(*soc)->getPinName = NULL;
 	(*soc)->setMap = NULL;
 	(*soc)->validGPIO = NULL;
@@ -59,6 +62,8 @@ void soc_register(struct soc_t **soc, char *brand, char *type) {
 		(*soc)->base_addr[i] = 0;
 		(*soc)->base_offs[i] = 0;
 	}
+	(*soc)->clock = NULL;
+	(*soc)->pwm = NULL;
 
 	(*soc)->next = socs;
 	socs = *soc;

--- a/src/soc/soc.h
+++ b/src/soc/soc.h
@@ -30,11 +30,15 @@ typedef struct soc_t {
 	} support;
 	
 	void *gpio[MAX_REG_AREA];
+	void *pwm;
+	void *clock;
 	int fd;
 	
 	unsigned long page_size;
 	unsigned long base_addr[MAX_REG_AREA];
 	unsigned long base_offs[MAX_REG_AREA];
+	unsigned long pwm_addr;
+	unsigned long clock_addr;
 	
 	int (*digitalWrite)(int, enum digital_value_t);
 	int (*digitalRead)(int);
@@ -45,7 +49,10 @@ typedef struct soc_t {
 	int (*setup)(void);
 	void (*setMap)(int *);
 	void (*setIRQ)(int *);
-	char *(*getPinName)(int);	
+	char *(*getPinName)(int);
+	int (*pwmSetClock)(int pin, uint32_t frequency);
+	int (*pwmSetRange)(int pin, uint32_t val);
+	int (*pwmWrite)(int pin, uint32_t val);
 
 	int (*validGPIO)(int);
 	int (*selectableFd)(int);

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -259,9 +259,8 @@ int wiringXSetup(char *name, void (*func)(int, const char *, ...)) {
 		wiringXLog(LOG_ERR, message);
 		return -1;
 	}
-	platform->setup();
-	
-	return 0;
+
+	return platform->setup();
 }
 
 char *wiringXPlatform(void) {
@@ -664,6 +663,60 @@ int wiringXSerialGetChar(int fd) {
 		wiringXLog(LOG_ERR, "wiringX serial interface has not been opened");
 		return -1;
 	}
+}
+
+int wiringXPwmSetClock(int pin, uint32_t frequency) {
+	if(platform != NULL) {
+		if(platform->pwmSetClock) {
+			int x = platform->pwmSetClock(pin, frequency);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling pwmSetClock", platform->name[0]);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support wiringXPwmSetClock", platform->name[0]);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
+int wiringXPwmSetRange(int pin, uint32_t duty) {
+	if(platform != NULL) {
+		if(platform->pwmSetRange) {
+			int x = platform->pwmSetRange(pin, duty);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling pwmSetRange", platform->name[0]);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support wiringXPwmSetRange", platform->name[0]);
+			wiringXGC();
+		}
+	}
+	return -1;
+}
+
+int wiringXPwmWrite(int pin, uint32_t val) {
+	if(platform != NULL) {
+		if(platform->pwmWrite) {
+			int x = platform->pwmWrite(pin, val);
+			if(x == -1) {
+				wiringXLog(LOG_ERR, "%s: error while calling pwmWrite", platform->name[0]);
+				wiringXGC();
+			} else {
+				return x;
+			}
+		} else {
+			wiringXLog(LOG_ERR, "%s: platform doesn't support wiringXPwmWrite", platform->name[0]);
+			wiringXGC();
+		}
+	}
+	return -1;
 }
 
 int wiringXSelectableFd(int gpio) {

--- a/src/wiringX.h
+++ b/src/wiringX.h
@@ -15,6 +15,7 @@ extern "C" {
 
 #include <errno.h>
 #include <syslog.h>
+#include <stdint.h>
 
 extern void (*wiringXLog)(int, const char *, ...);
 
@@ -38,7 +39,8 @@ enum pinmode_t {
 	PINMODE_NOT_SET = 0,
 	PINMODE_INPUT = 2,
 	PINMODE_OUTPUT = 4,
-	PINMODE_INTERRUPT = 8
+	PINMODE_INTERRUPT = 8,
+	PINMODE_PWM_OUTPUT = 16
 };
 
 enum isr_mode_t {
@@ -93,6 +95,16 @@ void wiringXSerialPuts(int, char *);
 void wiringXSerialPrintf(int, char *, ...);
 int wiringXSerialDataAvail(int);
 int wiringXSerialGetChar(int);
+
+// Set the hardware PCM Clock to frequency. Not all platforms supports
+// hardware PCM pins, or a different clock for each PCM pin. The RasPI has
+// only one clock for all pins, so the pin is ignored there.
+// frequency is in Hz, default is set to 100kHz.
+int wiringXPwmSetClock(int pin, uint32_t frequency);
+// Range for PWM counter, defaults to 1024
+int wiringXPwmSetRange(int pin, uint32_t range);
+// Write a value to the PWM counter.
+int wiringXPwmWrite(int pin, uint32_t val);
 
 char *wiringXPlatform(void);
 int wiringXValidGPIO(int);


### PR DESCRIPTION
I have added support for the hardware PWM pin of the raspberry PI 1. Theoretically all hardware PWM pins of the BCM2835 should be usable.

`int wiringXPwmSetClock(int pin, uint32_t frequency)`
Set the hardware PWM Clock to frequency. Even if the rpi does not support different clock values for  hardware PWM pins, other platforms may support this, so I have added the pin argument, even if this is not used on the rpi. Default for the clock is 100kHz.

`int wiringXPwmSetRange(int pin, uint32_t range)`
Range for PWM counter, defaults to 1024. On the BCM2835 the range can only be set for two different channels, so setting the range for two pins using the same channel to different values will not work and the last call will overwrite the range for the other pin. 

`int wiringXPwmWrite(int pin, uint32_t val)`
Write a value to the PWM counter.

A test program  wiringx-pwm is also added, you can test for example with  `./wiringx-pwm raspberrypi1b1 1 100000 256 128` This should set the pin 1 to a 50% duty cycle, using 100kHz clock.
