### PR TITLE
Let the debian package provide libwiringx-dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,5 +146,6 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_PACKAGE_DESCRIPTION "Cross-platform GPIO Interface")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Cross-platform GPIO Interface")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA ${PROJECT_SOURCE_DIR}/res/deb/prerm;)
+set(CPACK_DEBIAN_PACKAGE_PROVIDES libwiringx-dev)
 
 include(CPack)


### PR DESCRIPTION
It is standard to split runtime- and devel files in different packages.
Because the wiringX deb is currently one single package, provide the
virtual libwiringx-dev package to prepare for future splits (if any).

You know that I build my own libwiringX debs on the OBS. With this change, I am able to have my java bridge package build against both the cpack generated deb, as well as my own brew.

https://github.com/Artox/wiringX-java/blob/master/debian/control#L11
