### PR TITLE
explicitly pass read-only string where possible

### DIFF
--- a/src/platform/platform.c
+++ b/src/platform/platform.c
@@ -62,7 +62,7 @@ void platform_add_alias(struct platform_t **platform, char *name) {
 	(*platform)->nralias++;
 }
 
-struct platform_t *platform_get_by_name(char *name, int *nr) {
+struct platform_t *platform_get_by_name(const char *name, int *nr) {
 	struct platform_t *tmp = platforms;
 	int i = 0;
 	while(tmp) {

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -37,7 +37,7 @@ typedef struct platform_t {
 
 void platform_register(struct platform_t **, char *);
 void platform_add_alias(struct platform_t **, char *);
-struct platform_t *platform_get_by_name(char *, int *);
+struct platform_t *platform_get_by_name(const char *, int *);
 struct platform_t *platform_iterate(int);
 char *platform_iterate_name(int);
 int platform_gc(void);

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -205,7 +205,7 @@ void wiringXDefaultLog(int prio, const char *format_str, ...) {
 	errno = save_errno;
 }
 
-int wiringXSetup(char *name, void (*func)(int, const char *, ...)) {
+int wiringXSetup(const char *name, void (*func)(int, const char *, ...)) {
 	if(issetup == 0) {
 		issetup = 1;
 	} else {
@@ -363,7 +363,7 @@ int wiringXI2CWriteReg16(int fd, int reg, int data) {
 	return i2c_smbus_write_word_data(fd, reg, data);
 }
 
-int wiringXI2CSetup(char *path, int devId) {
+int wiringXI2CSetup(const char *path, int devId) {
 	int fd = 0;
 
 	if((fd = open(path, O_RDWR)) < 0) {
@@ -466,7 +466,7 @@ int wiringXSPISetup(int channel, int speed) {
 }
 #endif
 
-int wiringXSerialOpen(char *device, struct wiringXSerial_t wiringXSerial) {
+int wiringXSerialOpen(const char *device, struct wiringXSerial_t wiringXSerial) {
 	struct termios options;
 	speed_t myBaud;
 	int status = 0, fd = 0;
@@ -617,7 +617,7 @@ void wiringXSerialPutChar(int fd, unsigned char c) {
 	}
 }
 
-void wiringXSerialPuts(int fd, char *s) {
+void wiringXSerialPuts(int fd, const char *s) {
 	if(fd > 0) {
 		int x = write(fd, s, strlen(s));
 		if(x != strlen(s)) {
@@ -628,7 +628,7 @@ void wiringXSerialPuts(int fd, char *s) {
 	}
 }
 
-void wiringXSerialPrintf(int fd, char *message, ...) {
+void wiringXSerialPrintf(int fd, const char *message, ...) {
 	va_list argp;
 	char buffer[1024];
 

--- a/src/wiringX.h
+++ b/src/wiringX.h
@@ -64,7 +64,7 @@ typedef struct wiringXSerial_t {
 
 void delayMicroseconds(unsigned int);
 int pinMode(int, enum pinmode_t);
-int wiringXSetup(char *, void (*)(int, const char *, ...));
+int wiringXSetup(const char *, void (*)(int, const char *, ...));
 int wiringXGC(void);
 
 // int analogRead(int channel);
@@ -79,18 +79,18 @@ int wiringXI2CReadReg16(int, int);
 int wiringXI2CWrite(int, int);
 int wiringXI2CWriteReg8(int, int, int);
 int wiringXI2CWriteReg16(int, int, int);
-int wiringXI2CSetup(char *, int);
+int wiringXI2CSetup(const char *, int);
 
 int wiringXSPIGetFd(int channel);
 int wiringXSPIDataRW(int channel, unsigned char *data, int len);
 int wiringXSPISetup(int channel, int speed);
 
-int wiringXSerialOpen(char *, struct wiringXSerial_t);
+int wiringXSerialOpen(const char *, struct wiringXSerial_t);
 void wiringXSerialFlush(int);
 void wiringXSerialClose(int);
 void wiringXSerialPutChar(int, unsigned char);
-void wiringXSerialPuts(int, char *);
-void wiringXSerialPrintf(int, char *, ...);
+void wiringXSerialPuts(int, const char *);
+void wiringXSerialPrintf(int, const char *, ...);
 int wiringXSerialDataAvail(int);
 int wiringXSerialGetChar(int);
 


### PR DESCRIPTION
These functions do not modify the string passed to them, they might as
well not be allowed to. This prevents warnings such as the following:

warning: passing argument 1 of ‘wiringXI2CSetup’ discards ‘const’
qualifier from pointer target type [-Wdiscarded-qualifiers]
