### PR TITLE
Several fixes and code improvements

### DIFF
--- a/src/platform/hardkernel/odroidc1.c
+++ b/src/platform/hardkernel/odroidc1.c
@@ -77,9 +77,10 @@ static int odroidc1ValidGPIO(int pin) {
 }
 
 static int odroidc1Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	odroidc1->soc->setup();
-	odroidc1->soc->setMap(map);
-	odroidc1->soc->setIRQ(map);
+	odroidc1->soc->setMap(map, size);
+	odroidc1->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -87,7 +88,7 @@ void odroidc1Init(void) {
 	platform_register(&odroidc1, "odroidc1");
 
 	odroidc1->soc = soc_get("Amlogic", "S805");
-	odroidc1->soc->setMap(map);
+	odroidc1->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	odroidc1->digitalRead = odroidc1->soc->digitalRead;
 	odroidc1->digitalWrite = odroidc1->soc->digitalWrite;

--- a/src/platform/hardkernel/odroidc2.c
+++ b/src/platform/hardkernel/odroidc2.c
@@ -80,17 +80,19 @@ static int odroidc2ValidGPIO(int pin) {
 
 static int odroidc2Setup(void) {
 	int i = 0;
-	odroidc2->soc->setup();
-	odroidc2->soc->setMap(map);
+	const size_t size = sizeof(map) / sizeof(map[0]);
 
-	for(i=0;i<(sizeof(map)/sizeof(map[0]));i++) {
+	odroidc2->soc->setup();
+	odroidc2->soc->setMap(map, size);
+
+	for(i=0;i<size;i++) {
 		if(map[i] != -1) {
 			irq[i] = map[i]+122;
 		} else {
 			irq[i] = -1;
 		}
 	}
-	odroidc2->soc->setIRQ(irq);
+	odroidc2->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 
 	return 0;
 }
@@ -99,7 +101,7 @@ void odroidc2Init(void) {
 	platform_register(&odroidc2, "odroidc2");
 
 	odroidc2->soc = soc_get("Amlogic", "S905");
-	odroidc2->soc->setMap(map);
+	odroidc2->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	odroidc2->digitalRead = odroidc2->soc->digitalRead;
 	odroidc2->digitalWrite = odroidc2->soc->digitalWrite;

--- a/src/platform/hardkernel/odroidxu4.c
+++ b/src/platform/hardkernel/odroidxu4.c
@@ -83,9 +83,10 @@ static int odroidxu4ValidGPIO(int pin) {
 }
 
 static int odroidxu4Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	odroidxu4->soc->setup();
-	odroidxu4->soc->setMap(map);
-	odroidxu4->soc->setIRQ(map);
+	odroidxu4->soc->setMap(map, size);
+	odroidxu4->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -93,7 +94,7 @@ void odroidxu4Init(void) {
 	platform_register(&odroidxu4, "odroidxu4");
 
 	odroidxu4->soc = soc_get("Samsung", "Exynos5422");
-	odroidxu4->soc->setMap(map);
+	odroidxu4->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	odroidxu4->digitalRead = odroidxu4->soc->digitalRead;
 	odroidxu4->digitalWrite = odroidxu4->soc->digitalWrite;

--- a/src/platform/lemaker/bananapi1.c
+++ b/src/platform/lemaker/bananapi1.c
@@ -68,9 +68,10 @@ static int bananapi1ValidGPIO(int pin) {
 }
 
 static int bananapi1Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	bananapi1->soc->setup();
-	bananapi1->soc->setMap(map);
-	bananapi1->soc->setIRQ(map);
+	bananapi1->soc->setMap(map, size);
+	bananapi1->soc->setIRQ(map, size);
 	return 0;
 }
 

--- a/src/platform/lemaker/bananapim2.c
+++ b/src/platform/lemaker/bananapim2.c
@@ -94,9 +94,10 @@ static int bananapiM2DigitalWrite(int i, enum digital_value_t value) {
 }
 
 static int bananapiM2Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	bananapim2->soc->setup();
-	bananapim2->soc->setMap(map);
-	bananapim2->soc->setIRQ(map);
+	bananapim2->soc->setMap(map, size);
+	bananapim2->soc->setIRQ(map, size);
 	return 0;
 }
 

--- a/src/platform/linksprite/pcduino1.c
+++ b/src/platform/linksprite/pcduino1.c
@@ -87,9 +87,10 @@ static int pcduino1DigitalWrite(int i, enum digital_value_t value) {
 }
 
 static int pcduino1Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	pcduino1->soc->setup();
-	pcduino1->soc->setMap(map);
-	pcduino1->soc->setIRQ(map);
+	pcduino1->soc->setMap(map, size);
+	pcduino1->soc->setIRQ(map, size);
 	return 0;
 }
 

--- a/src/platform/raspberrypi/raspberrypi1b+.c
+++ b/src/platform/raspberrypi/raspberrypi1b+.c
@@ -54,9 +54,10 @@ static int raspberrypi1bpValidGPIO(int pin) {
 }
 
 static int raspberrypi1bpSetup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	raspberrypi1bp->soc->setup();
-	raspberrypi1bp->soc->setMap(map);
-	raspberrypi1bp->soc->setIRQ(map);
+	raspberrypi1bp->soc->setMap(map, size);
+	raspberrypi1bp->soc->setIRQ(map, size);
 	return 0;
 }
 

--- a/src/platform/raspberrypi/raspberrypi1b1.c
+++ b/src/platform/raspberrypi/raspberrypi1b1.c
@@ -45,9 +45,10 @@ static int raspberrypi1b1ValidGPIO(int pin) {
 }
 
 static int raspberrypi1b1Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	raspberrypi1b1->soc->setup();
-	raspberrypi1b1->soc->setMap(map);
-	raspberrypi1b1->soc->setIRQ(map);
+	raspberrypi1b1->soc->setMap(map, size);
+	raspberrypi1b1->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -55,7 +56,7 @@ void raspberrypi1b1Init(void) {
 	platform_register(&raspberrypi1b1, "raspberrypi1b1");
 
 	raspberrypi1b1->soc = soc_get("Broadcom", "2835");
-	raspberrypi1b1->soc->setMap(map);
+	raspberrypi1b1->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	raspberrypi1b1->digitalRead = raspberrypi1b1->soc->digitalRead;
 	raspberrypi1b1->digitalWrite = raspberrypi1b1->soc->digitalWrite;

--- a/src/platform/raspberrypi/raspberrypi1b2.c
+++ b/src/platform/raspberrypi/raspberrypi1b2.c
@@ -47,9 +47,10 @@ static int raspberrypi1b2ValidGPIO(int pin) {
 }
 
 static int raspberrypi1b2Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	raspberrypi1b2->soc->setup();
-	raspberrypi1b2->soc->setMap(map);
-	raspberrypi1b2->soc->setIRQ(map);
+	raspberrypi1b2->soc->setMap(map, size);
+	raspberrypi1b2->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -57,7 +58,7 @@ void raspberrypi1b2Init(void) {
 	platform_register(&raspberrypi1b2, "raspberrypi1b2");
 
 	raspberrypi1b2->soc = soc_get("Broadcom", "2835");
-	raspberrypi1b2->soc->setMap(map);
+	raspberrypi1b2->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	raspberrypi1b2->digitalRead = raspberrypi1b2->soc->digitalRead;
 	raspberrypi1b2->digitalWrite = raspberrypi1b2->soc->digitalWrite;

--- a/src/platform/raspberrypi/raspberrypi2.c
+++ b/src/platform/raspberrypi/raspberrypi2.c
@@ -54,9 +54,10 @@ static int raspberrypi2ValidGPIO(int pin) {
 }
 
 static int raspberrypi2Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	raspberrypi2->soc->setup();
-	raspberrypi2->soc->setMap(map);
-	raspberrypi2->soc->setIRQ(map);
+	raspberrypi2->soc->setMap(map, size);
+	raspberrypi2->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -64,7 +65,7 @@ void raspberrypi2Init(void) {
 	platform_register(&raspberrypi2, "raspberrypi2");
 
 	raspberrypi2->soc = soc_get("Broadcom", "2836");
-	raspberrypi2->soc->setMap(map);
+	raspberrypi2->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	raspberrypi2->digitalRead = raspberrypi2->soc->digitalRead;
 	raspberrypi2->digitalWrite = raspberrypi2->soc->digitalWrite;

--- a/src/platform/raspberrypi/raspberrypi3.c
+++ b/src/platform/raspberrypi/raspberrypi3.c
@@ -54,9 +54,10 @@ static int raspberrypi3ValidGPIO(int pin) {
 }
 
 static int raspberrypi3Setup(void) {
+	const size_t size = sizeof(map) / sizeof(map[0]);
 	raspberrypi3->soc->setup();
-	raspberrypi3->soc->setMap(map);
-	raspberrypi3->soc->setIRQ(map);
+	raspberrypi3->soc->setMap(map, size);
+	raspberrypi3->soc->setIRQ(map, size);
 	return 0;
 }
 
@@ -69,7 +70,7 @@ void raspberrypi3Init(void) {
 	 * Broadcom 2836.
 	 */
 	raspberrypi3->soc = soc_get("Broadcom", "2836");
-	raspberrypi3->soc->setMap(map);
+	raspberrypi3->soc->setMap(map, sizeof(map) / sizeof(map[0]));
 
 	raspberrypi3->digitalRead = raspberrypi3->soc->digitalRead;
 	raspberrypi3->digitalWrite = raspberrypi3->soc->digitalWrite;

--- a/src/platform/solidrun/hummingboard_base_pro_dq.c
+++ b/src/platform/solidrun/hummingboard_base_pro_dq.c
@@ -90,8 +90,8 @@ static int hummingboardBaseProDQISR(int i, enum isr_mode_t mode) {
 
 static int hummingboardBaseProDQSetup(void) {
 	hummingboardBaseProDQ->soc->setup();
-	hummingboardBaseProDQ->soc->setMap(map);
-	hummingboardBaseProDQ->soc->setIRQ(irq);
+	hummingboardBaseProDQ->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardBaseProDQ->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 	return 0;
 }
 

--- a/src/platform/solidrun/hummingboard_base_pro_sdl.c
+++ b/src/platform/solidrun/hummingboard_base_pro_sdl.c
@@ -89,8 +89,8 @@ static int hummingboardBaseProSDLISR(int i, enum isr_mode_t mode) {
 
 static int hummingboardBaseProSDLSetup(void) {
 	hummingboardBaseProSDL->soc->setup();
-	hummingboardBaseProSDL->soc->setMap(map);
-	hummingboardBaseProSDL->soc->setIRQ(irq);
+	hummingboardBaseProSDL->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardBaseProSDL->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 	return 0;
 }
 
@@ -99,8 +99,8 @@ void hummingboardBaseProSDLInit(void) {
 	platform_add_alias(&hummingboardBaseProSDL, "hummingboard_pro_sdl");
 
 	hummingboardBaseProSDL->soc = soc_get("NXP", "IMX6SDLRM");
-	hummingboardBaseProSDL->soc->setMap(map);
-	hummingboardBaseProSDL->soc->setIRQ(irq);
+	hummingboardBaseProSDL->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardBaseProSDL->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 
 	hummingboardBaseProSDL->digitalRead = hummingboardBaseProSDL->soc->digitalRead;
 	hummingboardBaseProSDL->digitalWrite = hummingboardBaseProSDL->soc->digitalWrite;

--- a/src/platform/solidrun/hummingboard_gate_edge_dq.c
+++ b/src/platform/solidrun/hummingboard_gate_edge_dq.c
@@ -143,8 +143,8 @@ static int hummingboardGateEdgeDQISR(int i, enum isr_mode_t mode) {
 
 static int hummingboardGateEdgeDQSetup(void) {
 	hummingboardGateEdgeDQ->soc->setup();
-	hummingboardGateEdgeDQ->soc->setMap(map);
-	hummingboardGateEdgeDQ->soc->setIRQ(irq);
+	hummingboardGateEdgeDQ->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardGateEdgeDQ->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 	return 0;
 }
 
@@ -153,8 +153,8 @@ void hummingboardGateEdgeDQInit(void) {
 	platform_add_alias(&hummingboardGateEdgeDQ, "hummingboard_gate_dq");
 
 	hummingboardGateEdgeDQ->soc = soc_get("NXP", "IMX6DQRM");
-	hummingboardGateEdgeDQ->soc->setMap(map);
-	hummingboardGateEdgeDQ->soc->setIRQ(irq);
+	hummingboardGateEdgeDQ->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardGateEdgeDQ->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 
 	hummingboardGateEdgeDQ->digitalRead = hummingboardGateEdgeDQ->soc->digitalRead;
 	hummingboardGateEdgeDQ->digitalWrite = hummingboardGateEdgeDQ->soc->digitalWrite;

--- a/src/platform/solidrun/hummingboard_gate_edge_sdl.c
+++ b/src/platform/solidrun/hummingboard_gate_edge_sdl.c
@@ -107,8 +107,8 @@ static int hummingboardGateEdgeSDLISR(int i, enum isr_mode_t mode) {
 
 static int hummingboardGateEdgeSDLSetup(void) {
 	hummingboardGateEdgeSDL->soc->setup();
-	hummingboardGateEdgeSDL->soc->setMap(map);
-	hummingboardGateEdgeSDL->soc->setIRQ(irq);
+	hummingboardGateEdgeSDL->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardGateEdgeSDL->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 	return 0;
 }
 
@@ -117,8 +117,8 @@ void hummingboardGateEdgeSDLInit(void) {
 	platform_add_alias(&hummingboardGateEdgeSDL, "hummingboard_gate_sdl");
 
 	hummingboardGateEdgeSDL->soc = soc_get("NXP", "IMX6SDLRM");
-	hummingboardGateEdgeSDL->soc->setMap(map);
-	hummingboardGateEdgeSDL->soc->setIRQ(irq);
+	hummingboardGateEdgeSDL->soc->setMap(map, sizeof(map) / sizeof(map[0]));
+	hummingboardGateEdgeSDL->soc->setIRQ(irq, sizeof(irq) / sizeof(irq[0]));
 
 	hummingboardGateEdgeSDL->digitalRead = hummingboardGateEdgeSDL->soc->digitalRead;
 	hummingboardGateEdgeSDL->digitalWrite = hummingboardGateEdgeSDL->soc->digitalWrite;

--- a/src/soc/allwinner/a10.c
+++ b/src/soc/allwinner/a10.c
@@ -233,12 +233,14 @@ static char *allwinnerA10GetPinName(int pin) {
 	return allwinnerA10->layout[pin].name;
 }
 
-static void allwinnerA10SetMap(int *map) {
+static void allwinnerA10SetMap(int *map, size_t size) {
 	allwinnerA10->map = map;
+	allwinnerA10->map_size = size;
 }
 
-static void allwinnerA10SetIRQ(int *irq) {
+static void allwinnerA10SetIRQ(int *irq, size_t size) {
 	allwinnerA10->irq = irq;
+	allwinnerA10->irq_size = size;
 }
 
 static int allwinnerA10DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/allwinner/a31s.c
+++ b/src/soc/allwinner/a31s.c
@@ -229,12 +229,14 @@ static char *allwinnerA31sGetPinName(int pin) {
 	return allwinnerA31s->layout[pin].name;
 }
 
-static void allwinnerA31sSetMap(int *map) {
+static void allwinnerA31sSetMap(int *map, size_t size) {
 	allwinnerA31s->map = map;
+	allwinnerA31s->map_size = size;
 }
 
-static void allwinnerA31sSetIRQ(int *irq) {
+static void allwinnerA31sSetIRQ(int *irq, size_t size) {
 	allwinnerA31s->irq = irq;
+	allwinnerA31s->irq_size = size;
 }
 
 static int allwinnerA31sDigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/amlogic/s805.c
+++ b/src/soc/amlogic/s805.c
@@ -202,12 +202,14 @@ static char *amlogicS805GetPinName(int pin) {
 	return amlogicS805->layout[pin].name;
 }
 
-static void amlogicS805SetMap(int *map) {
+static void amlogicS805SetMap(int *map, size_t size) {
 	amlogicS805->map = map;
+	amlogicS805->map_size = size;
 }
 
-static void amlogicS805SetIRQ(int *irq) {
+static void amlogicS805SetIRQ(int *irq, size_t size) {
 	amlogicS805->irq = irq;
+	amlogicS805->irq_size = size;
 }
 
 static int amlogicS805DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/amlogic/s905.c
+++ b/src/soc/amlogic/s905.c
@@ -205,12 +205,14 @@ static char *amlogicS905GetPinName(int pin) {
 	return amlogicS905->layout[pin].name;
 }
 
-static void amlogicS905SetMap(int *map) {
+static void amlogicS905SetMap(int *map, size_t size) {
 	amlogicS905->map = map;
+	amlogicS905->map_size = size;
 }
 
-static void amlogicS905SetIRQ(int *irq) {
+static void amlogicS905SetIRQ(int *irq, size_t size) {
 	amlogicS905->irq = irq;
+	amlogicS905->irq_size = size;
 }
 
 static int amlogicS905DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/broadcom/2835.c
+++ b/src/soc/broadcom/2835.c
@@ -143,12 +143,14 @@ static char *broadcom2835GetPinName(int pin) {
 	return broadcom2835->layout[pin].name;
 }
 
-static void broadcom2835SetMap(int *map) {
+static void broadcom2835SetMap(int *map, size_t size) {
 	broadcom2835->map = map;
+	broadcom2835->map_size = size;
 }
 
-static void broadcom2835SetIRQ(int *irq) {
+static void broadcom2835SetIRQ(int *irq, size_t size) {
 	broadcom2835->irq = irq;
+	broadcom2835->irq_size = size;
 }
 
 static int broadcom2835DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/broadcom/2836.c
+++ b/src/soc/broadcom/2836.c
@@ -143,12 +143,14 @@ static char *broadcom2836GetPinName(int pin) {
 	return broadcom2836->layout[pin].name;
 }
 
-static void broadcom2836SetMap(int *map) {
+static void broadcom2836SetMap(int *map, size_t size) {
 	broadcom2836->map = map;
+	broadcom2836->map_size = size;
 }
 
-static void broadcom2836SetIRQ(int *irq) {
+static void broadcom2836SetIRQ(int *irq, size_t size) {
 	broadcom2836->irq = irq;
+	broadcom2836->irq_size = size;
 }
 
 static int broadcom2836DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/nxp/imx6dqrm.c
+++ b/src/soc/nxp/imx6dqrm.c
@@ -271,12 +271,14 @@ static char *nxpIMX6DQRMGetPinName(int pin) {
 	return nxpIMX6DQRM->layout[pin].name;
 }
 
-static void nxpIMX6DQRMSetMap(int *map) {
+static void nxpIMX6DQRMSetMap(int *map, size_t size) {
 	nxpIMX6DQRM->map = map;
+	nxpIMX6DQRM->map_size = size;
 }
 
-static void nxpIMX6DQRMSetIRQ(int *irq) {
+static void nxpIMX6DQRMSetIRQ(int *irq, size_t size) {
 	nxpIMX6DQRM->irq = irq;
+	nxpIMX6DQRM->irq_size = size;
 }
 
 static int nxpIMX6DQRMDigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/nxp/imx6sdlrm.c
+++ b/src/soc/nxp/imx6sdlrm.c
@@ -271,12 +271,14 @@ static char *nxpIMX6SDLRMGetPinName(int pin) {
 	return nxpIMX6SDLRM->layout[pin].name;
 }
 
-static void nxpIMX6SDLRMSetMap(int *map) {
+static void nxpIMX6SDLRMSetMap(int *map, size_t size) {
 	nxpIMX6SDLRM->map = map;
+	nxpIMX6SDLRM->map_size = size;
 }
 
-static void nxpIMX6SDLRMSetIRQ(int *irq) {
+static void nxpIMX6SDLRMSetIRQ(int *irq, size_t size) {
 	nxpIMX6SDLRM->irq = irq;
+	nxpIMX6SDLRM->irq_size = size;
 }
 
 static int nxpIMX6SDLRMDigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/samsung/exynos5422.c
+++ b/src/soc/samsung/exynos5422.c
@@ -303,12 +303,14 @@ static char *exynos5422GetPinName(int pin) {
 	return exynos5422->layout[pin].name;
 }
 
-static void exynos5422SetMap(int *map) {
+static void exynos5422SetMap(int *map, size_t size) {
 	exynos5422->map = map;
+	exynos5422->map_size = size;
 }
 
-static void exynos5422SetIRQ(int *irq) {
+static void exynos5422SetIRQ(int *irq, size_t size) {
 	exynos5422->irq = irq;
+	exynos5422->irq_size = size;
 }
 
 static int exynos5422DigitalWrite(int i, enum digital_value_t value) {

--- a/src/soc/soc.c
+++ b/src/soc/soc.c
@@ -34,6 +34,9 @@ void soc_register(struct soc_t **soc, char *brand, char *type) {
 	strcpy((*soc)->chip, type);	
 
 	(*soc)->map = NULL;
+	(*soc)->map_size = 0;
+	(*soc)->irq = NULL;
+	(*soc)->irq_size = 0;
 	(*soc)->layout = NULL;
 	(*soc)->support.isr_modes = 0;
 
@@ -41,18 +44,20 @@ void soc_register(struct soc_t **soc, char *brand, char *type) {
 	
 	(*soc)->page_size = 0;
 
-	(*soc)->gc = NULL;
-	(*soc)->selectableFd = NULL;
-
-	(*soc)->pinMode = NULL;
-	(*soc)->setup = NULL;
-	(*soc)->digitalRead = NULL;
 	(*soc)->digitalWrite = NULL;
-	(*soc)->getPinName = NULL;
-	(*soc)->setMap = NULL;
-	(*soc)->validGPIO = NULL;
+	(*soc)->digitalRead = NULL;
+	(*soc)->pinMode = NULL;
 	(*soc)->isr = NULL;
 	(*soc)->waitForInterrupt = NULL;
+
+	(*soc)->setup = NULL;
+	(*soc)->setMap = NULL;
+	(*soc)->setIRQ = NULL;
+	(*soc)->getPinName = NULL;
+
+	(*soc)->validGPIO = NULL;
+	(*soc)->selectableFd = NULL;
+	(*soc)->gc = NULL;
 
 	for (i = 0; i < MAX_REG_AREA; ++i) {
 		(*soc)->gpio[i] = NULL;
@@ -64,11 +69,11 @@ void soc_register(struct soc_t **soc, char *brand, char *type) {
 	socs = *soc;
 }
 
-void soc_writel(unsigned long addr, uint32_t val) {
+void soc_writel(uintptr_t addr, uint32_t val) {
 	*((volatile uint32_t *)(addr)) = val;
 }
 
-uint32_t soc_readl(unsigned long addr) {
+uint32_t soc_readl(uintptr_t addr) {
 	return *((volatile uint32_t *)(addr));
 }
 

--- a/src/soc/soc.h
+++ b/src/soc/soc.h
@@ -10,6 +10,7 @@
 #define __WIRINGX_SOC_H_
 
 #include "../wiringX.h"
+#include <stddef.h>
 #include <stdint.h>
 
 #define MAX_REG_AREA	8
@@ -21,7 +22,9 @@ typedef struct soc_t {
 	char chip[255];
 
 	int *map;
+	size_t map_size;
 	int *irq;
+	size_t irq_size;
 	
 	struct layout_t *layout;
 
@@ -32,9 +35,9 @@ typedef struct soc_t {
 	void *gpio[MAX_REG_AREA];
 	int fd;
 	
-	unsigned long page_size;
-	unsigned long base_addr[MAX_REG_AREA];
-	unsigned long base_offs[MAX_REG_AREA];
+	size_t page_size;
+	uintptr_t base_addr[MAX_REG_AREA];
+	uintptr_t base_offs[MAX_REG_AREA];
 	
 	int (*digitalWrite)(int, enum digital_value_t);
 	int (*digitalRead)(int);
@@ -43,8 +46,8 @@ typedef struct soc_t {
 	int (*waitForInterrupt)(int, int);
 
 	int (*setup)(void);
-	void (*setMap)(int *);
-	void (*setIRQ)(int *);
+	void (*setMap)(int *, size_t size);
+	void (*setIRQ)(int *, size_t size);
 	char *(*getPinName)(int);	
 
 	int (*validGPIO)(int);
@@ -56,8 +59,8 @@ typedef struct soc_t {
 
 void soc_register(struct soc_t **, char *, char *);
 struct soc_t *soc_get(char *, char *);
-void soc_writel(unsigned long, uint32_t);
-uint32_t soc_readl(unsigned long);
+void soc_writel(uintptr_t, uint32_t);
+uint32_t soc_readl(uintptr_t);
 int soc_gc(void);
 
 int soc_sysfs_check_gpio(struct soc_t *, char *);

--- a/src/wiringX.c
+++ b/src/wiringX.c
@@ -267,7 +267,7 @@ int wiringXSetup(const char *name, void (*func)(int, const char *, ...)) {
 char *wiringXPlatform(void) {
 	if(platform == NULL) {
 		wiringXLog(LOG_ERR, "wiringX has not been properly setup (no platform has been selected)");
-		return -1;
+		return NULL;
 	}
 	return platform->name[namenr];
 }
@@ -388,8 +388,8 @@ int wiringXSPIDataRW(int channel, unsigned char *data, int len) {
 	memset(&tmp, 0, sizeof(tmp));
 	channel &= 1;
 
-	tmp.tx_buf = (unsigned long)data;
-	tmp.rx_buf = (unsigned long)data;
+	tmp.tx_buf = (uintptr_t)data;
+	tmp.rx_buf = (uintptr_t)data;
 	tmp.len = len;
 	tmp.delay_usecs = spi[channel].delay;
 	tmp.speed_hz = spi[channel].speed;


### PR DESCRIPTION
- pass sizes of map/irq arrays in setMap()/setIRQ() functions, as `sizeof(array) / sizeof(array[0])` trick doesn't work when you pass an array as function parameter;
- some soc_t fields in soc_register() weren't initialized;
- support for 64-bit systems: use uintptr_t when dealing with pointers and size_t when dealing with sizes/counts;
- fix wrong return type in wiringXPlatform() function.