### PR TITLE
Use `soc_t::map_size` instead of `sizeof` in GC functions

### DIFF
--- a/src/soc/allwinner/a10.c
+++ b/src/soc/allwinner/a10.c
@@ -401,12 +401,10 @@ static int allwinnerA10WaitForInterrupt(int i, int ms) {
 static int allwinnerA10GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0, x = 0;
+	int i = 0, x = 0;
 
 	if(allwinnerA10->map != NULL) {
-		l = sizeof(allwinnerA10->map)/sizeof(allwinnerA10->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<allwinnerA10->map_size;i++) {
 			pin = &allwinnerA10->layout[allwinnerA10->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/allwinner/a31s.c
+++ b/src/soc/allwinner/a31s.c
@@ -330,12 +330,10 @@ static int allwinnerA31sPinMode(int i, enum pinmode_t mode) {
 
 static int allwinnerA31sGC(void) {
 	struct layout_t *pin = NULL;
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(allwinnerA31s->map != NULL) {
-		l = sizeof(allwinnerA31s->map)/sizeof(allwinnerA31s->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<allwinnerA31s->map_size;i++) {
 			pin = &allwinnerA31s->layout[allwinnerA31s->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/amlogic/s805.c
+++ b/src/soc/amlogic/s805.c
@@ -360,12 +360,10 @@ static int amlogicS805WaitForInterrupt(int i, int ms) {
 static int amlogicS805GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(amlogicS805->map != NULL) {
-		l = sizeof(amlogicS805->map)/sizeof(amlogicS805->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<amlogicS805->map_size;i++) {
 			pin = &amlogicS805->layout[amlogicS805->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/amlogic/s905.c
+++ b/src/soc/amlogic/s905.c
@@ -364,12 +364,10 @@ static int amlogicS905WaitForInterrupt(int i, int ms) {
 static int amlogicS905GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(amlogicS905->map != NULL) {
-		l = sizeof(amlogicS905->map)/sizeof(amlogicS905->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<amlogicS905->map_size;i++) {
 			pin = &amlogicS905->layout[amlogicS905->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/broadcom/2835.c
+++ b/src/soc/broadcom/2835.c
@@ -301,12 +301,10 @@ static int broadcom2835WaitForInterrupt(int i, int ms) {
 static int broadcom2835GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(broadcom2835->map != NULL) {
-		l = sizeof(broadcom2835->map)/sizeof(broadcom2835->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<broadcom2835->map_size;i++) {
 			pin = &broadcom2835->layout[broadcom2835->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/broadcom/2836.c
+++ b/src/soc/broadcom/2836.c
@@ -301,12 +301,10 @@ static int broadcom2836WaitForInterrupt(int i, int ms) {
 static int broadcom2836GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(broadcom2836->map != NULL) {
-		l = sizeof(broadcom2836->map)/sizeof(broadcom2836->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<broadcom2836->map_size;i++) {
 			pin = &broadcom2836->layout[broadcom2836->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/nxp/imx6dqrm.c
+++ b/src/soc/nxp/imx6dqrm.c
@@ -432,12 +432,10 @@ static int nxpIMX6DQRMWaitForInterrupt(int i, int ms) {
 static int nxpIMX6DQRMGC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(nxpIMX6DQRM->map != NULL) {
-		l = sizeof(nxpIMX6DQRM->map)/sizeof(nxpIMX6DQRM->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<nxpIMX6DQRM->map_size;i++) {
 			pin = &nxpIMX6DQRM->layout[nxpIMX6DQRM->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/nxp/imx6sdlrm.c
+++ b/src/soc/nxp/imx6sdlrm.c
@@ -432,12 +432,10 @@ static int nxpIMX6SDLRMWaitForInterrupt(int i, int ms) {
 static int nxpIMX6SDLRMGC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(nxpIMX6SDLRM->map != NULL) {
-		l = sizeof(nxpIMX6SDLRM->map)/sizeof(nxpIMX6SDLRM->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<nxpIMX6SDLRM->map_size;i++) {
 			pin = &nxpIMX6SDLRM->layout[nxpIMX6SDLRM->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);

--- a/src/soc/samsung/exynos5422.c
+++ b/src/soc/samsung/exynos5422.c
@@ -462,12 +462,10 @@ static int exynos5422WaitForInterrupt(int i, int ms) {
 static int exynos5422GC(void) {
 	struct layout_t *pin = NULL;
 	char path[PATH_MAX];
-	int i = 0, l = 0;
+	int i = 0;
 
 	if(exynos5422->map != NULL) {
-		l = sizeof(exynos5422->map)/sizeof(exynos5422->map[0]);
-
-		for(i=0;i<l;i++) {
+		for(i=0;i<exynos5422->map_size;i++) {
 			pin = &exynos5422->layout[exynos5422->map[i]];
 			if(pin->mode == PINMODE_OUTPUT) {
 				pinMode(i, PINMODE_INPUT);


### PR DESCRIPTION
Something I forgot to include into my previous pull request: to actually use the new `map_size` field in SOC garbage collection functions.

Also, one strange thing that I noticed, is that some platforms call `setMap()`/`setIRQ()` in both `platformInit()` and `platformSetup()` functions. Is this intended approach or an oversight?