### PR TITLE
Fix rk3399DigitalRead not working issue

### DIFF
--- a/src/soc/rockchip/rk3399.c
+++ b/src/soc/rockchip/rk3399.c
@@ -344,7 +344,7 @@ static int rk3399DigitalWrite(int i, enum digital_value_t value) {
 		return -1;
 	}
 
-	data_reg = (volatile uint32_t *)(rk3399->gpio[pin->bank] + pin->data.offset + GPIO_SWPROTA_DR);
+	data_reg = (volatile uint32_t *)(rk3399->gpio[pin->bank] + pin->data.offset + GPIO_SWPORTA_DR);
 	if(value == HIGH) {
 		*data_reg |= (1 << (pin->data.bit));
 	} else if(value == LOW) {


### PR DESCRIPTION
Previously read was tested by writting to the same data register that was used for write operation, and then read back the value.

It has been found that this is not how the hardware is supposed to work, and requires accessing a different register for read operation.