### PR TITLE
Added support for block reading and writing

### DIFF
--- a/src/i2c-dev.c
+++ b/src/i2c-dev.c
@@ -70,4 +70,39 @@ extern inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value) {
 	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_WORD_DATA, &data);
 }
 
+
+extern inline __s32 i2c_smbus_read_data_block(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	if(i2c_smbus_access(fd, I2C_SMBUS_READ, cmd, I2C_SMBUS_I2C_BLOCK_DATA, &data) < 0) {
+		return -1;
+	} else {
+		memcpy(block, data.block+1, block_size);
+		return data.block[0];
+	}
+}
+
+extern inline __s32 i2c_smbus_write_data_block(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	memcpy(data.block+1, block, block_size);
+	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_I2C_BLOCK_BROKEN, &data);
+}
+
+extern inline __s32 i2c_smbus_write_data_block_with_size(int fd, int cmd, unsigned char *block, int block_size) {
+	union i2c_smbus_data data;
+	if (block_size > I2C_SMBUS_BLOCK_MAX) {
+		block_size = I2C_SMBUS_BLOCK_MAX;
+	}
+	data.block[0] = block_size;
+	memcpy(data.block+1, block, block_size);
+	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_I2C_BLOCK_DATA, &data);
+}
+
 #endif

--- a/src/i2c-dev.c
+++ b/src/i2c-dev.c
@@ -70,7 +70,6 @@ extern inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value) {
 	return i2c_smbus_access(fd, I2C_SMBUS_WRITE, cmd, I2C_SMBUS_WORD_DATA, &data);
 }
 
-
 extern inline __s32 i2c_smbus_read_data_block(int fd, int cmd, unsigned char *block, int block_size) {
 	union i2c_smbus_data data;
 	if (block_size > I2C_SMBUS_BLOCK_MAX) {

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -34,5 +34,8 @@ inline __s32 i2c_smbus_read_byte_data(int fd, int cmd);
 inline __s32 i2c_smbus_write_byte_data(int fd, int cmd, int value);
 inline __s32 i2c_smbus_read_word_data(int fd, int cmd);
 inline __s32 i2c_smbus_write_word_data(int fd, int cmd, __u16 value);
+inline __s32 i2c_smbus_read_data_block(int fd, int cmd, unsigned char *block, int block_size);
+inline __s32 i2c_smbus_write_data_block(int fd, int cmd, unsigned char *block, int block_size);
+inline __s32 i2c_smbus_write_data_block_with_size(int fd, int cmd, unsigned char *block, int block_size);
 
 #endif

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -111,8 +111,6 @@ static struct spi_t spi[2] = {
 	} while(0)
 #endif
 
-
-
 /* Both the delayMicroseconds and the delayMicrosecondsHard
    are taken from wiringPi */
 static void delayMicrosecondsHard(unsigned int howLong) {

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -408,7 +408,6 @@ EXPORT int wiringXI2CWriteReg16(int fd, int reg, int data) {
 	return i2c_smbus_write_word_data(fd, reg, data);
 }
 
-
 EXPORT int wiringXI2CWriteBlockData(int fd, int reg, unsigned char *block, int block_size) {
 	return i2c_smbus_write_data_block(fd, reg, block, block_size);
 }

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -14,9 +14,7 @@
 #include <errno.h>
 #include <string.h>
 #include <fcntl.h>
-#include <time.h>
 #include <termios.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>
 #ifndef __FreeBSD__
@@ -113,10 +111,7 @@ static struct spi_t spi[2] = {
 	} while(0)
 #endif
 
-#ifdef __riscv
-typedef time_t __time_t;
-typedef suseconds_t __suseconds_t;
-#endif
+
 
 /* Both the delayMicroseconds and the delayMicrosecondsHard
    are taken from wiringPi */

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -123,8 +123,8 @@ static void delayMicrosecondsHard(unsigned int howLong) {
 	tLong.tv_sec  = howLong / 1000000;
 	tLong.tv_usec = howLong % 1000000;
 #else
-	tLong.tv_sec  = (__time_t)howLong / 1000000;
-	tLong.tv_usec = (__suseconds_t)howLong % 1000000;
+	tLong.tv_sec  = (time_t)howLong / 1000000;
+	tLong.tv_usec = (suseconds_t)howLong % 1000000;
 #endif
 	timeradd(&tNow, &tLong, &tEnd);
 
@@ -139,7 +139,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 	long int uSecs = howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #else
-	long int uSecs = (__time_t)howLong % 1000000;
+	long int uSecs = (time_t)howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #endif
 
@@ -151,7 +151,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 #ifdef _WIN32
 		sleeper.tv_sec = wSecs;
 #else
-		sleeper.tv_sec = (__time_t)wSecs;	
+		sleeper.tv_sec = (time_t)wSecs;	
 #endif
 		sleeper.tv_nsec = (long)(uSecs * 1000L);
 		nanosleep(&sleeper, NULL);
@@ -392,6 +392,10 @@ EXPORT int wiringXI2CReadReg16(int fd, int reg) {
 	return i2c_smbus_read_word_data(fd, reg);
 }
 
+EXPORT int wiringXI2CReadBlockData(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_read_data_block(fd, reg, block, block_size);
+}
+
 EXPORT int wiringXI2CWrite(int fd, int data) {
 	return i2c_smbus_write_byte(fd, data);
 }
@@ -402,6 +406,15 @@ EXPORT int wiringXI2CWriteReg8(int fd, int reg, int data) {
 
 EXPORT int wiringXI2CWriteReg16(int fd, int reg, int data) {
 	return i2c_smbus_write_word_data(fd, reg, data);
+}
+
+
+EXPORT int wiringXI2CWriteBlockData(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_write_data_block(fd, reg, block, block_size);
+}
+
+EXPORT int wiringXI2CWriteBlockDataWithSize(int fd, int reg, unsigned char *block, int block_size) {
+	return i2c_smbus_write_data_block_with_size(fd, reg, block, block_size);
 }
 
 EXPORT int wiringXI2CSetup(const char *path, int devId) {

--- a/src/wiringx.c
+++ b/src/wiringx.c
@@ -113,6 +113,11 @@ static struct spi_t spi[2] = {
 	} while(0)
 #endif
 
+#ifdef __riscv
+typedef time_t __time_t;
+typedef suseconds_t __suseconds_t;
+#endif
+
 /* Both the delayMicroseconds and the delayMicrosecondsHard
    are taken from wiringPi */
 static void delayMicrosecondsHard(unsigned int howLong) {
@@ -123,8 +128,8 @@ static void delayMicrosecondsHard(unsigned int howLong) {
 	tLong.tv_sec  = howLong / 1000000;
 	tLong.tv_usec = howLong % 1000000;
 #else
-	tLong.tv_sec  = (time_t)howLong / 1000000;
-	tLong.tv_usec = (suseconds_t)howLong % 1000000;
+	tLong.tv_sec  = (__time_t)howLong / 1000000;
+	tLong.tv_usec = (__suseconds_t)howLong % 1000000;
 #endif
 	timeradd(&tNow, &tLong, &tEnd);
 
@@ -139,7 +144,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 	long int uSecs = howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #else
-	long int uSecs = (time_t)howLong % 1000000;
+	long int uSecs = (__time_t)howLong % 1000000;
 	unsigned int wSecs = howLong / 1000000;
 #endif
 
@@ -151,7 +156,7 @@ EXPORT void delayMicroseconds(unsigned int howLong) {
 #ifdef _WIN32
 		sleeper.tv_sec = wSecs;
 #else
-		sleeper.tv_sec = (time_t)wSecs;	
+		sleeper.tv_sec = (__time_t)wSecs;
 #endif
 		sleeper.tv_nsec = (long)(uSecs * 1000L);
 		nanosleep(&sleeper, NULL);

--- a/src/wiringx.h
+++ b/src/wiringx.h
@@ -13,6 +13,9 @@
 extern "C" {
 #endif
 
+
+#include <time.h>
+#include <sys/time.h>
 #include <errno.h>
 #include <syslog.h>
 
@@ -65,6 +68,12 @@ typedef struct wiringXSerial_t {
 	unsigned int stopbits;
 	unsigned int flowcontrol;
 } wiringXSerial_t;
+
+
+#ifdef __riscv
+typedef time_t __time_t;
+typedef suseconds_t __suseconds_t;
+#endif
 
 void delayMicroseconds(unsigned int);
 int pinMode(int, enum pinmode_t);

--- a/src/wiringx.h
+++ b/src/wiringx.h
@@ -13,7 +13,6 @@
 extern "C" {
 #endif
 
-
 #include <time.h>
 #include <sys/time.h>
 #include <errno.h>
@@ -68,7 +67,6 @@ typedef struct wiringXSerial_t {
 	unsigned int stopbits;
 	unsigned int flowcontrol;
 } wiringXSerial_t;
-
 
 #ifdef __riscv
 typedef time_t __time_t;

--- a/src/wiringx.h
+++ b/src/wiringx.h
@@ -80,9 +80,13 @@ int wiringXISR(int, enum isr_mode_t);
 int wiringXI2CRead(int);
 int wiringXI2CReadReg8(int, int);
 int wiringXI2CReadReg16(int, int);
+int wiringXI2CReadBlockData(int, int, unsigned char*, int);
 int wiringXI2CWrite(int, int);
 int wiringXI2CWriteReg8(int, int, int);
 int wiringXI2CWriteReg16(int, int, int);
+int wiringXI2CWriteBlockData(int, int, unsigned char*, int);
+int wiringXI2CWriteBlockDataWithSize(int, int, unsigned char*, int);
+
 int wiringXI2CSetup(const char *, int);
 
 int wiringXSPIGetFd(int channel);


### PR DESCRIPTION
Hello there,

Thanks for the great work with this library.

I added three functions to support reading and writing blocks with a specified size to the I2C device. This can particularly be useful if a slave device replies back with a DWORD (e.g., one of its registers is 32-bit). For writing, I added two versions, one that implicitly sends the size as the first byte to the slave device and one that doesn't.

I tested these changes on the Milk-V Duo S using their fork of WiringX and it works fine. All I need to do is replace /usr/lib/libwiringx.so on the Milk-V with the new binary and include it in the sdk toolchain as well.

I also replaced __time_t and __suseconds_t with time_t and suseconds_t, respectively. This allows it to be cross-compiled for rv64 with musl.

Thanks!